### PR TITLE
Realm overview page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { ShopsComponent } from './components/shops/shops.component';
 import { WingBuffsComponent } from './components/wing-buffs/wing-buffs.component';
 import { SettingsComponent } from './components/settings/settings.component';
 import { SearchComponent } from './components/search/search.component';
+import { RealmComponent } from './components/realm/realm.component';
 
 const title = (title: string) => `${title} - Sky Planner`;
 
@@ -26,6 +27,7 @@ const routes: Routes = [
   { path: 'event-instance/:guid', component: EventInstanceComponent, title: title('Event') },
   { path: 'item', component: ItemsComponent, title: title('Items') },
   { path: 'realm', component: RealmsComponent, title: title('Realms') },
+  { path: 'realm/:guid', component: RealmComponent, title: title('Realm') },
   { path: 'search', component: SearchComponent, title: title('Search') },
   { path: 'season', component: SeasonsComponent, title: title('Seasons') },
   { path: 'season/:guid', component: SeasonComponent, title: title('Season') },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,10 +32,12 @@ import { WingBuffsComponent } from './components/wing-buffs/wing-buffs.component
 import { SettingsComponent } from './components/settings/settings.component';
 import { SearchComponent } from './components/search/search.component';
 import { DayjsPipe } from './pipes/dayjs.pipe';
+import { RealmComponent } from './components/realm/realm.component';
 
 @NgModule({
   declarations: [
     AppComponent,
+    DayjsPipe,
     SpiritTreeComponent,
     NodeComponent,
     ItemComponent,
@@ -61,7 +63,7 @@ import { DayjsPipe } from './pipes/dayjs.pipe';
     WingBuffsComponent,
     SettingsComponent,
     SearchComponent,
-    DayjsPipe
+    RealmComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/realm/realm.component.html
+++ b/src/app/components/realm/realm.component.html
@@ -1,0 +1,30 @@
+<div class="card container">
+  <h1 class="h2 mb-0">{{ realm.name }}</h1>
+</div>
+
+<!-- Spirits -->
+<div class="card container container-scroll-x mt-2">
+  <h2 class="h3">Spirits</h2>
+  <div class="container-flex">
+    <!-- Spirit trees -->
+    <ng-container *ngIf="spirits">
+      <ng-container *ngFor="let spirit of spirits;">
+        <div class="tree-wrapper" *ngIf="spirit.tree">
+          <app-spirit-tree [tree]="spirit.tree" [name]="spirit.name">
+            <!-- Link to spirit -->
+            <div name>
+              <a [routerLink]="['/spirit', spirit.guid]" [queryParams]="{ highlightTree: spirit.tree.guid }">
+                {{ spirit.name }}
+              </a>
+            </div>
+          </app-spirit-tree>
+        </div>
+      </ng-container>
+    </ng-container>
+  </div>
+</div>
+
+<ng-template #costHover>
+  <span>Total cost of all the items in this tree.</span><br/>
+  <span class="remaining-cost">Remaining cost of items not yet unlocked.</span>
+</ng-template>

--- a/src/app/components/realm/realm.component.less
+++ b/src/app/components/realm/realm.component.less
@@ -1,0 +1,7 @@
+app-spirit-tree {
+  vertical-align: bottom;
+}
+
+.tree-wrapper {
+  display: inline-block;
+}

--- a/src/app/components/realm/realm.component.ts
+++ b/src/app/components/realm/realm.component.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute, ParamMap } from '@angular/router';
+import { IRealm } from 'src/app/interfaces/realm.interface';
+import { ISpirit } from 'src/app/interfaces/spirit.interface';
+import { DataService } from 'src/app/services/data.service';
+
+@Component({
+  selector: 'app-realm',
+  templateUrl: './realm.component.html',
+  styleUrls: ['./realm.component.less']
+})
+export class RealmComponent {
+  realm!: IRealm;
+
+  spirits: Array<ISpirit> = [];
+
+  constructor(
+    private readonly _dataService: DataService,
+    private readonly _route: ActivatedRoute
+  ) {
+    _route.queryParamMap.subscribe(p => this.onQueryChanged(p));
+    _route.paramMap.subscribe(p => this.onParamsChanged(p));
+  }
+
+  onQueryChanged(params: ParamMap): void {
+  }
+
+  onParamsChanged(params: ParamMap): void {
+    const guid = params.get('guid');
+    this.initializeRealm(guid!);
+  }
+
+  private initializeRealm(guid: string): void {
+    this.realm = this._dataService.guidMap.get(guid!) as IRealm;
+
+    this.spirits = [];
+    this.realm?.areas?.forEach(area => {
+      area.spirits?.filter(s => s.type === 'Regular' || s.type === 'Elder').forEach(spirit => {
+        this.spirits.push(spirit);
+      });
+    });
+  }
+}

--- a/src/app/components/realms/realms.component.html
+++ b/src/app/components/realms/realms.component.html
@@ -13,6 +13,11 @@
     </div>
     <!-- Image -->
     <div *ngIf="realm.imageUrl" class="p-rel img" [style.background-image]="'url('+realm.imageUrl+')'"></div>
+    <!-- Overview --> <!-- For now only show overview if realm has spirits. -->
+    <a *ngIf="spiritCount[realm.guid]" class="mt-2 item link" [routerLink]="['/realm', realm.guid]">
+      <mat-icon class="menu-icon" fontIcon="article"></mat-icon>
+      <span class="menu-label">Overview</span>
+    </a>
     <!-- Areas -->
     <!-- <div class="mt-2 item areas">
       Areas


### PR DESCRIPTION
Adds an Overview button to the realms page.
Links to a page showing all regular (/elder) spirits in the realm.

Overview is hidden for Home until more content is added to the realm page.

Closes #7