### PR TITLE
Previews

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -43,7 +43,7 @@ const routes: Routes = [
   { path: 'spirit', component: SpiritsComponent, title: title('Spirits') },
   { path: 'spirit/:guid', component: SpiritComponent, title: TitleResolver },
   { path: 'ts', component: TravelingSpiritsComponent, title: title('Traveling Spirits') },
-  { path: 'rs', component: ReturningSpiritsComponent, title: title('Returning Spirits') },
+  { path: 'rs', component: ReturningSpiritsComponent, title: title('Special Visits') },
   { path: 'rs/:guid', component: ReturningSpiritComponent, title: TitleResolver },
   { path: 'wing-buff', component: WingBuffsComponent, title: title('Wing Buffs') },
   { path: 'editor', loadChildren: () => import('./editor/editor.module').then(m => m.EditorModule) },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -47,6 +47,8 @@ import { SpiritCardComponent } from './components/spirit-card/spirit-card.compon
 import { BlankComponent } from './components/blank/blank.component';
 import { ClockComponent } from './components/clock/clock.component';
 import { ItemIconsComponent } from './components/item/item-icons/item-icons.component';
+import { FormsModule } from '@angular/forms';
+import { WikiLinkComponent } from './components/util/wiki-link/wiki-link.component';
 
 @NgModule({
   declarations: [
@@ -91,12 +93,14 @@ import { ItemIconsComponent } from './components/item/item-icons/item-icons.comp
     SpiritCardComponent,
     BlankComponent,
     ClockComponent,
-    ItemIconsComponent
+    ItemIconsComponent,
+    WikiLinkComponent
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
     HttpClientModule,
+    FormsModule,
     NgbModule,
     LayoutModule,
     MatIconModule

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -47,7 +47,6 @@ import { SpiritCardComponent } from './components/spirit-card/spirit-card.compon
 import { BlankComponent } from './components/blank/blank.component';
 import { ClockComponent } from './components/clock/clock.component';
 import { ItemIconsComponent } from './components/item/item-icons/item-icons.component';
-import { FormsModule } from '@angular/forms';
 import { WikiLinkComponent } from './components/util/wiki-link/wiki-link.component';
 
 @NgModule({
@@ -100,7 +99,6 @@ import { WikiLinkComponent } from './components/util/wiki-link/wiki-link.compone
     BrowserModule,
     AppRoutingModule,
     HttpClientModule,
-    FormsModule,
     NgbModule,
     LayoutModule,
     MatIconModule

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,6 +46,7 @@ import { EventCardComponent } from './components/event-card/event-card.component
 import { SpiritCardComponent } from './components/spirit-card/spirit-card.component';
 import { BlankComponent } from './components/blank/blank.component';
 import { ClockComponent } from './components/clock/clock.component';
+import { ItemIconsComponent } from './components/item/item-icons/item-icons.component';
 
 @NgModule({
   declarations: [
@@ -89,7 +90,8 @@ import { ClockComponent } from './components/clock/clock.component';
     EventCardComponent,
     SpiritCardComponent,
     BlankComponent,
-    ClockComponent
+    ClockComponent,
+    ItemIconsComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/credits/credits.component.html
+++ b/src/app/components/credits/credits.component.html
@@ -55,13 +55,15 @@
   <div class="sky-card-body">
     <div class="container ws-pl">
       <p>
-        Various assets such as icons are loaded directly from the
-        <a href="https://sky-children-of-the-light.fandom.com/wiki/Sky:_Children_of_the_Light_Wiki" target="_blank">Sky:CotL Fandom wiki</a>.
+        Various images such as item icons and spirits are loaded directly from the
+        <a href="https://sky-children-of-the-light.fandom.com/wiki/Sky:_Children_of_the_Light_Wiki" target="_blank">Sky: Children of the Light Fandom wiki</a>.<br/>
+        This project only links to the original assets. For more information refer to
+        <a href="https://www.fandom.com/licensing" target="_blank">Fandom licensing page</a>.<br/>
       </p>
       <p class="mb-0">
-        This project only <i>links</i> to these original assets. For more information refer to
-        <a href="https://www.fandom.com/licensing" target="_blank">Fandom licensing page</a>.<br/>
-        In particular many icons from the wiki are contributed to the wiki by:
+        A special thanks to the wiki contributors for all their hard work and for giving me permission to show images from the wiki on Sky Planner.
+        You can find out more about <a href="https://sky-children-of-the-light.fandom.com/wiki/Special:Community">the wiki contributors here</a>.<br/>
+        In particular many icons on the wiki are contributed to the wiki by:
       </p>
       <div class="flex-credits">
         <div class="flex-credit">

--- a/src/app/components/event-instance/event-instance.component.html
+++ b/src/app/components/event-instance/event-instance.component.html
@@ -8,10 +8,7 @@
   <div class="sky-card-body">
     <div class="grid grid-2">
       <!-- Wiki -->
-      <a class="container colspan-2" *ngIf="instance.event?._wiki?.href" [href]="instance.event._wiki?.href" target="_blank">
-        <mat-icon class="menu-icon">question_mark</mat-icon>
-        <span class="menu-label">Wiki</span>
-      </a>
+      <app-wiki-link [wiki]="instance.event._wiki" [aClass]="'container colspan-2'"></app-wiki-link>
       <!-- Date -->
       <div class="container" [class.expired]="state === 'ended'">
         <mat-icon class="menu-icon">calendar_month</mat-icon>

--- a/src/app/components/events/events.component.html
+++ b/src/app/components/events/events.component.html
@@ -3,10 +3,7 @@
     <h1 class="h2 mb-0">Events</h1>
   </div>
   <div class="sky-card-body">
-    <a class="container d-inline-block" href="https://sky-children-of-the-light.fandom.com/wiki/Special_Events" target="_blank">
-      <mat-icon class="menu-icon">question_mark</mat-icon>
-      <span class="menu-label">Wiki</span>
-    </a>
+    <app-wiki-link [wiki]="{href: 'https://sky-children-of-the-light.fandom.com/wiki/Special_Events'}"></app-wiki-link>
   </div>
 </div>
 

--- a/src/app/components/item/item-icons/item-icons.component.html
+++ b/src/app/components/item/item-icons/item-icons.component.html
@@ -1,0 +1,10 @@
+  <ng-container *ngIf="item">
+    <!-- Season icon (top right) -->
+    <app-icon *ngIf="item.season?.iconUrl" class="img-tr" [src]="item.season?.iconUrl || '#season-candle'"></app-icon>
+    <!-- Season pass item (top left) -->
+    <app-icon *ngIf="item.group === 'Ultimate'" class="img-tl seasonal" [src]="'#season-heart'"></app-icon>
+    <!-- Elder item (top left) -->
+    <app-icon *ngIf="item.group === 'Elder'" class="img-tl" [src]="'#ascended-candle'"></app-icon>
+    <!-- IAP item (top left) -->
+    <app-icon *ngIf="item.iaps?.length" class="img-tl currency" [src]="'#gift'"></app-icon>
+  </ng-container>

--- a/src/app/components/item/item-icons/item-icons.component.less
+++ b/src/app/components/item/item-icons/item-icons.component.less
@@ -1,0 +1,19 @@
+* {
+  pointer-events: none;
+}
+
+.img-tl {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: var(--icon-size-group);
+  height: var(--icon-size-group);
+}
+
+.img-tr {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: var(--icon-size-group);
+  height: var(--icon-size-group);
+}

--- a/src/app/components/item/item-icons/item-icons.component.ts
+++ b/src/app/components/item/item-icons/item-icons.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { IItem } from 'src/app/interfaces/item.interface';
+
+@Component({
+  selector: 'app-item-icons',
+  templateUrl: './item-icons.component.html',
+  styleUrls: ['./item-icons.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ItemIconsComponent {
+  @Input() item?: IItem;
+}

--- a/src/app/components/item/item.component.html
+++ b/src/app/components/item/item.component.html
@@ -4,13 +4,4 @@
   (click)="iconClick($event)">
 </app-icon>
 <span class="emote-level" *ngIf="item.type === ItemType.Emote">Lv{{item.level}}</span>
-<ng-container *ngIf="showSubIcons">
-  <!-- Season icon (top right) -->
-  <app-icon *ngIf="item.season?.iconUrl" class="img-tr" [src]="item.season?.iconUrl || '#season-candle'"></app-icon>
-  <!-- Season pass item (top left) -->
-  <app-icon *ngIf="item.group === 'Ultimate'" class="img-tl seasonal" [src]="'#season-heart'"></app-icon>
-  <!-- Elder item (top left) -->
-  <app-icon *ngIf="item.group === 'Elder'" class="img-tl" [src]="'#ascended-candle'"></app-icon>
-  <!-- IAP item (top left) -->
-  <app-icon *ngIf="item.iaps?.length" class="img-tl currency" [src]="'#gift'"></app-icon>
-</ng-container>
+<app-item-icons *ngIf="showSubIcons" [item]="item"></app-item-icons>

--- a/src/app/components/item/item.component.less
+++ b/src/app/components/item/item.component.less
@@ -37,19 +37,3 @@
   left: 0;
   font-size: 12px;
 }
-
-.img-tl {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: var(--icon-size-group);
-  height: var(--icon-size-group);
-}
-
-.img-tr {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: var(--icon-size-group);
-  height: var(--icon-size-group);
-}

--- a/src/app/components/item/item.component.ts
+++ b/src/app/components/item/item.component.ts
@@ -1,13 +1,16 @@
-import { Component, HostBinding, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostBinding, Input, OnDestroy, OnInit } from '@angular/core';
+import { SubscriptionLike } from 'rxjs';
 import { IItem, ItemType } from 'src/app/interfaces/item.interface';
 import { DebugService } from 'src/app/services/debug.service';
+import { EventService } from 'src/app/services/event.service';
 
 @Component({
   selector: 'app-item',
   templateUrl: './item.component.html',
-  styleUrls: ['./item.component.less']
+  styleUrls: ['./item.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ItemComponent {
+export class ItemComponent implements OnInit, OnDestroy {
   @Input() item!: IItem;
   @HostBinding('class.large')
   @Input() large = false;
@@ -18,10 +21,24 @@ export class ItemComponent {
 
   ItemType = ItemType;
 
+  _sub?: SubscriptionLike;
+
   constructor(
-    private readonly _debug: DebugService
+    private readonly _debug: DebugService,
+    private readonly _eventService: EventService,
+    private readonly _changeDetectorRef: ChangeDetectorRef
   ) {
 
+  }
+  ngOnInit(): void {
+    this._sub = this._eventService.itemToggled.subscribe(item => {
+      if (item.guid !== this.item?.guid) { return; }
+      this._changeDetectorRef.markForCheck();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this._sub?.unsubscribe();
   }
 
   iconClick(event: MouseEvent): void {

--- a/src/app/components/items/items.component.html
+++ b/src/app/components/items/items.component.html
@@ -142,15 +142,11 @@
         <a class="item-icon item-icon-large info-grid-icon d-inline-block" [routerLink]="selectedItemNav?.route" [queryParams]="selectedItemNav?.extras?.queryParams">
           <app-item [item]="selectedItem" [large]="true" [hoverHighlight]="false"></app-item>
         </a>
-        <a *ngIf="selectedItem?._wiki?.href" class="info-grid-find container" [href]="selectedItem._wiki?.href">
-          <mat-icon class="menu-icon">question_mark</mat-icon>
-          <span class="menu-label">Wiki</span>
-        </a>
+        <app-wiki-link [wiki]="selectedItem._wiki" [aClass]="'info-grid-find container'"></app-wiki-link>
         <a *ngIf="selectedItemNav" class="info-grid-find container" [routerLink]="selectedItemNav.route" [queryParams]="selectedItemNav.extras?.queryParams">
           <mat-icon class="menu-icon">search</mat-icon>
           <span class="menu-label">Find item</span>
         </a>
-
       </div>
     </div>
   </div>

--- a/src/app/components/items/items.component.html
+++ b/src/app/components/items/items.component.html
@@ -157,7 +157,7 @@
 </div>
 
 <!-- Field guide -->
-<ng-container *ngIf="shownItems?.length">
+<ng-container *ngIf="previewItems?.length">
   <div class="sky-card mt">
     <div class="sky-card-header header-previews" (click)="togglePreviews()">
       <h2 class="h3 mb-0">
@@ -166,9 +166,10 @@
       </h2>
     </div>
     <div class="sky-card-body" *ngIf="showFieldGuide">
-      <div class="sky-flex flex-wrap" *ngIf="showFieldGuide">
-        <ng-container *ngFor="let item of shownItems">
-          <div *ngIf="item.previewUrl" (click)="selectItem($event, item)"
+      <div class="sky-flex flex-wrap" *ngIf="previewItems?.length">
+        <ng-container *ngFor="let item of previewItems">
+          <div *ngIf="item.previewUrl" (click)="openItem(item)"
+          [class.highlight]="item && item === selectedItem"
             class="item-preview link" [ngbTooltip]="item.name" container="body" placement="auto">
             <div class="pad">
               <img [src]="item.previewUrl" class="preview-img" loading="lazy">

--- a/src/app/components/items/items.component.html
+++ b/src/app/components/items/items.component.html
@@ -164,7 +164,7 @@
     <div class="sky-card-body" *ngIf="showFieldGuide">
       <div class="sky-flex flex-wrap" *ngIf="previewItems?.length">
         <ng-container *ngFor="let item of previewItems">
-          <div *ngIf="item.previewUrl" (click)="openItem(item)"
+          <div *ngIf="item.previewUrl" (click)="selectItem($event, item)"
           [class.highlight]="item && item === selectedItem"
             class="item-preview link" [ngbTooltip]="item.name" container="body" placement="auto">
             <div class="pad">

--- a/src/app/components/items/items.component.html
+++ b/src/app/components/items/items.component.html
@@ -12,79 +12,79 @@
   <div class="sky-card-body">
     <div class="flex">
       <!-- Outfits -->
-      <div class="flex-item category" [class.highlight]="type === 'Outfit'"
+      <div class="item-icon category" [class.highlight]="type === 'Outfit'"
       [ngbTooltip]="'Outfits'" container="body" placement="bottom"
         (click)="selectCategory('Outfit')">
         <mat-icon svgIcon="outfit"></mat-icon>
       </div>
       <!-- Shoes -->
-      <div class="flex-item category" [class.highlight]="type === 'Shoes'"
+      <div class="item-icon category" [class.highlight]="type === 'Shoes'"
       [ngbTooltip]="'Shoes'" container="body" placement="bottom"
         (click)="selectCategory('Shoes')">
         <mat-icon svgIcon="shoes"></mat-icon>
       </div>
       <!-- Masks -->
-      <div class="flex-item category" [class.highlight]="type === 'Mask'"
+      <div class="item-icon category" [class.highlight]="type === 'Mask'"
       [ngbTooltip]="'Masks'" container="body" placement="bottom"
         (click)="selectCategory('Mask')">
         <mat-icon svgIcon="mask"></mat-icon>
       </div>
       <!-- Face Accessories -->
-      <div class="flex-item category" [class.highlight]="type === 'FaceAccessory'"
+      <div class="item-icon category" [class.highlight]="type === 'FaceAccessory'"
       [ngbTooltip]="'Face accessories'" container="body" placement="bottom"
         (click)="selectCategory('FaceAccessory')">
         <mat-icon svgIcon="face-acc"></mat-icon>
       </div>
       <!-- Necklaces -->
-      <div class="flex-item category" [class.highlight]="type === 'Necklace'"
+      <div class="item-icon category" [class.highlight]="type === 'Necklace'"
       [ngbTooltip]="'Necklaces'" container="body" placement="bottom"
         (click)="selectCategory('Necklace')">
         <mat-icon svgIcon="necklace"></mat-icon>
       </div>
       <!-- Hair -->
-      <div class="flex-item category" [class.highlight]="type === 'Hair'"
+      <div class="item-icon category" [class.highlight]="type === 'Hair'"
       [ngbTooltip]="'Hair'" container="body" placement="bottom"
         (click)="selectCategory('Hair')">
         <mat-icon svgIcon="hair"></mat-icon>
       </div>
       <!-- Hats -->
-      <div class="flex-item category" [class.highlight]="type === 'Hat'"
+      <div class="item-icon category" [class.highlight]="type === 'Hat'"
       [ngbTooltip]="'Hats'" container="body" placement="bottom"
         (click)="selectCategory('Hat')">
         <mat-icon svgIcon="hat"></mat-icon>
       </div>
       <!-- Capes -->
-      <div class="flex-item category" [class.highlight]="type === 'Cape'"
+      <div class="item-icon category" [class.highlight]="type === 'Cape'"
       [ngbTooltip]="'Capes'" container="body" placement="bottom"
         (click)="selectCategory('Cape')">
         <mat-icon svgIcon="cape"></mat-icon>
       </div>
       <!-- Held -->
-      <div class="flex-item category" [class.highlight]="type === 'Held'"
+      <div class="item-icon category" [class.highlight]="type === 'Held'"
       [ngbTooltip]="'Held props'" container="body" placement="bottom"
         (click)="selectCategory('Held')">
         <mat-icon svgIcon="held"></mat-icon>
       </div>
       <!-- Prop -->
-      <div class="flex-item category" [class.highlight]="type === 'Prop'"
+      <div class="item-icon category" [class.highlight]="type === 'Prop'"
       [ngbTooltip]="'Props'" container="body" placement="bottom"
         (click)="selectCategory('Prop')">
         <mat-icon svgIcon="prop"></mat-icon>
       </div>
       <!-- Emote -->
-      <div class="flex-item category" [class.highlight]="type === 'Emote'"
+      <div class="item-icon category" [class.highlight]="type === 'Emote'"
       [ngbTooltip]="'Emotes'" container="body" placement="bottom"
         (click)="selectCategory('Emote')">
         <mat-icon svgIcon="emote"></mat-icon>
       </div>
       <!-- Stance -->
-      <div class="flex-item category" [class.highlight]="type === 'Stance'"
+      <div class="item-icon category" [class.highlight]="type === 'Stance'"
       [ngbTooltip]="'Stances'" container="body" placement="bottom"
         (click)="selectCategory('Stance')">
         <mat-icon svgIcon="stance"></mat-icon>
       </div>
       <!-- Call -->
-      <div class="flex-item category" [class.highlight]="type === 'Call'"
+      <div class="item-icon category" [class.highlight]="type === 'Call'"
       [ngbTooltip]="'Calls'" container="body" placement="bottom"
         (click)="selectCategory('Call')">
         <mat-icon svgIcon="call"></mat-icon>
@@ -110,14 +110,14 @@
 
   <div class="sky-card-body">
     <div class="flex item-grid" [class.gap-half-y]="columns">
-      <div class="flex-item" *ngIf="showNone && columns">
+      <div class="item-icon" *ngIf="showNone && columns">
         <div class="item-none">
           <mat-icon class="" svgIcon="none"></mat-icon>
         </div>
       </div>
       <ng-container *ngFor="let item of shownItems; let i = index">
         <div class="item-col-hr" [style.display]="!columns || !i || ((i+offsetNone) % columns) ? undefined : 'block'"></div>
-        <div class="flex-item">
+        <div class="item-icon">
           <app-item [item]="item" [showSubIcons]="true" class="a"
             (click)="selectItem($event, item)"
             [class.highlight]="item && item === selectedItem"
@@ -139,7 +139,7 @@
     </div>
     <div class="sky-card-body">
       <div class="info-grid">
-        <a class="flex-item flex-item-large info-grid-icon d-inline-block" [routerLink]="selectedItemNav?.route" [queryParams]="selectedItemNav?.extras?.queryParams">
+        <a class="item-icon item-icon-large info-grid-icon d-inline-block" [routerLink]="selectedItemNav?.route" [queryParams]="selectedItemNav?.extras?.queryParams">
           <app-item [item]="selectedItem" [large]="true" [hoverHighlight]="false"></app-item>
         </a>
         <a *ngIf="selectedItemNav" class="info-grid-find container" [routerLink]="selectedItemNav.route" [queryParams]="selectedItemNav.extras?.queryParams">
@@ -148,9 +148,34 @@
         </a>
         <a *ngIf="previewHref" class="info-grid-find container" [href]="previewHref" target="_blank">
           <mat-icon class="menu-icon">visibility</mat-icon>
-          <span class="menu-label">Preview</span>
+          <span class="menu-label">Preview on Sky wiki</span>
         </a>
       </div>
     </div>
   </div>
 </div>
+
+<!-- Field guide -->
+<ng-container *ngIf="shownItems?.length">
+  <div class="sky-card mt">
+    <div class="sky-card-header header-previews" (click)="togglePreviews()">
+      <h2 class="h3 mb-0">
+        Field guide
+        <mat-icon>{{showFieldGuide ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}</mat-icon>
+      </h2>
+    </div>
+    <div class="sky-card-body" *ngIf="showFieldGuide">
+      <div class="sky-flex flex-wrap" *ngIf="showFieldGuide">
+        <ng-container *ngFor="let item of shownItems">
+          <div *ngIf="item.previewUrl" (click)="selectItem($event, item)"
+            class="item-preview link" [ngbTooltip]="item.name" container="body" placement="auto">
+            <div class="pad">
+              <img [src]="item.previewUrl" class="preview-img" loading="lazy">
+              <app-item-icons [item]="item"></app-item-icons>
+            </div>
+          </div>
+        </ng-container>
+      </div>
+    </div>
+  </div>
+</ng-container>

--- a/src/app/components/items/items.component.html
+++ b/src/app/components/items/items.component.html
@@ -140,7 +140,7 @@
     <div class="sky-card-body">
       <div class="info-grid">
         <a class="item-icon item-icon-large info-grid-icon d-inline-block" [routerLink]="selectedItemNav?.route" [queryParams]="selectedItemNav?.extras?.queryParams">
-          <app-item [item]="selectedItem" [large]="true" [hoverHighlight]="false"></app-item>
+          <app-item [item]="selectedItem" [large]="true" [highlight]="true" [hoverHighlight]="false"></app-item>
         </a>
         <app-wiki-link [wiki]="selectedItem._wiki" [aClass]="'info-grid-find container'"></app-wiki-link>
         <a *ngIf="selectedItemNav" class="info-grid-find container" [routerLink]="selectedItemNav.route" [queryParams]="selectedItemNav.extras?.queryParams">

--- a/src/app/components/items/items.component.html
+++ b/src/app/components/items/items.component.html
@@ -142,14 +142,15 @@
         <a class="item-icon item-icon-large info-grid-icon d-inline-block" [routerLink]="selectedItemNav?.route" [queryParams]="selectedItemNav?.extras?.queryParams">
           <app-item [item]="selectedItem" [large]="true" [hoverHighlight]="false"></app-item>
         </a>
+        <a *ngIf="selectedItem?._wiki?.href" class="info-grid-find container" [href]="selectedItem._wiki?.href">
+          <mat-icon class="menu-icon">question_mark</mat-icon>
+          <span class="menu-label">Wiki</span>
+        </a>
         <a *ngIf="selectedItemNav" class="info-grid-find container" [routerLink]="selectedItemNav.route" [queryParams]="selectedItemNav.extras?.queryParams">
           <mat-icon class="menu-icon">search</mat-icon>
           <span class="menu-label">Find item</span>
         </a>
-        <a *ngIf="previewHref" class="info-grid-find container" [href]="previewHref" target="_blank">
-          <mat-icon class="menu-icon">visibility</mat-icon>
-          <span class="menu-label">Preview on Sky wiki</span>
-        </a>
+
       </div>
     </div>
   </div>

--- a/src/app/components/items/items.component.less
+++ b/src/app/components/items/items.component.less
@@ -103,6 +103,8 @@ app-item.a {
   border-radius: var(--border-radius);
   border: var(--border-solid);
   overflow: hidden;
+  min-width: 96px; // reserve some space while image is loading.
+  text-align: center;
 }
 
 .preview-img {

--- a/src/app/components/items/items.component.less
+++ b/src/app/components/items/items.component.less
@@ -48,6 +48,30 @@
   font-weight: bold;
 }
 
+.header-previews {
+  cursor: pointer;
+  &:hover {
+    color: var(--color-link-hover);
+  }
+
+  mat-icon {
+    vertical-align: middle;
+  }
+}
+
+.item-icon {
+  position: relative;
+  width: var(--item-size);
+  height: var(--item-size);
+  background: var(--color-background);
+  border-radius: var(--border-radius)
+}
+
+.item-icon-large {
+  width: var(--item-size-large);
+  height: var(--item-size-large);
+}
+
 .item-col-hr {
   display: none;
   flex-basis: 100%;
@@ -70,6 +94,21 @@
 
 app-item.a {
   cursor: pointer;
+}
+
+.item-preview {
+  position: relative;
+  display: inline-block;
+  background: var(--color-background);
+  border-radius: var(--border-radius);
+  border: var(--border-solid);
+  overflow: hidden;
+}
+
+.preview-img {
+  height: 192px;
+  max-height: 192px;
+  object-fit: scale-down;
 }
 
 .info-grid {

--- a/src/app/components/items/items.component.ts
+++ b/src/app/components/items/items.component.ts
@@ -21,7 +21,6 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
   // Item details.
   selectedItem?: IItem;
   selectedItemNav?: INavigationTarget;
-  previewHref?: string;
   _previewObserver?: IntersectionObserver;
   _scrollToPreview = true;
 
@@ -74,7 +73,7 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
       this.shownItems = Object.values(this.emotes);
     }
     this.shownUnlocked = this.typeUnlocked[this.type] ?? 0;
-    this.showNone = this.type === ItemType.Necklace || this.type === ItemType.Hat || this.type === ItemType.Held;
+    this.showNone = this.type === ItemType.Necklace || this.type === ItemType.Hat || this.type === ItemType.Held || this.type === ItemType.Shoes || this.type === ItemType.FaceAccessory;
     //this.showNone = false;
     this.offsetNone = this.showNone ? 1 : 0;
 
@@ -82,7 +81,6 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
     if (itemGuid) {
       this.selectedItem = this._dataService.guidMap.get(itemGuid) as IItem;
       this.selectedItemNav = this.selectedItem ? NavigationHelper.getItemSource(this.selectedItem) : undefined;
-      this.previewHref = this.selectedItem ? NavigationHelper.getPreviewLink(this.selectedItem) : undefined;
     }
   }
 

--- a/src/app/components/items/items.component.ts
+++ b/src/app/components/items/items.component.ts
@@ -1,6 +1,5 @@
-import { AfterContentInit, AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { ActivatedRoute, ParamMap, Params, Router, convertToParamMap } from '@angular/router';
-import { ReplaySubject, Subject, interval } from 'rxjs';
 import { INavigationTarget, NavigationHelper } from 'src/app/helpers/navigation-helper';
 import { IItem, ItemType } from 'src/app/interfaces/item.interface';
 import { DataService } from 'src/app/services/data.service';
@@ -116,11 +115,9 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
   }
 
   selectCategory(type: string) {
-    const searchParams = new URL(location.href).searchParams;
-    searchParams.set('type', type);
-    this.selectedItem ? searchParams.set('item', this.selectedItem.guid) : searchParams.delete('item');
-    const queryParams: Params = {};
-    for (const [k,v] of searchParams.entries()) { queryParams[k] = v; }
+    const queryParams = NavigationHelper.getQueryParams(location.href);
+    queryParams['type'] = type;
+    this.selectedItem ? queryParams['item'] = this.selectedItem.guid : delete queryParams['item'];
 
     this._router.navigate([], { queryParams, replaceUrl: true });
   }
@@ -185,7 +182,7 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
     window.history.replaceState(window.history.state, '', url.pathname + url.search);
 
     // Select item
-    this.onQueryParamsChanged(convertToParamMap({ type: this.type, item: item.guid }));
+    this.onQueryParamsChanged(convertToParamMap(NavigationHelper.getQueryParams(url)));
 
     // Scroll to item if out of view.
     if (this._scrollToPreview) {

--- a/src/app/components/items/items.component.ts
+++ b/src/app/components/items/items.component.ts
@@ -23,7 +23,7 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
   selectedItem?: IItem;
   selectedItemNav?: INavigationTarget;
   _previewObserver?: IntersectionObserver;
-  _scrollToPreview = true;
+  _scrollToPreview = 0;
 
   columns?: number;
 
@@ -56,9 +56,11 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     this._previewObserver = new IntersectionObserver(entries => {
       entries.forEach(entry => {
-        this._scrollToPreview = !entry.isIntersecting || entry.intersectionRatio < 0.5;
+        this._scrollToPreview = entry.isIntersecting && entry.intersectionRatio >= 0.9
+        ? 0 : entry.boundingClientRect.top > 0 ? -1 : 1;
+        console.log(entry, this._scrollToPreview);
       });
-    }, { threshold: [0.5] });
+    }, { threshold: [0, 0.1, 0.9, 1] });
     this._previewObserver.observe(this.itemDiv.nativeElement);
   }
 
@@ -187,8 +189,8 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
     // Scroll to item if out of view.
     if (this._scrollToPreview) {
       setTimeout(() => {
-        this.itemDiv.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      });
+        this.itemDiv.nativeElement.scrollIntoView({ behavior: 'smooth', block: this._scrollToPreview > 0 ? 'start' : 'end' });
+      }, 50);
     }
   }
 

--- a/src/app/components/items/items.component.ts
+++ b/src/app/components/items/items.component.ts
@@ -58,7 +58,6 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
       entries.forEach(entry => {
         this._scrollToPreview = entry.isIntersecting && entry.intersectionRatio >= 0.9
         ? 0 : entry.boundingClientRect.top > 0 ? -1 : 1;
-        console.log(entry, this._scrollToPreview);
       });
     }, { threshold: [0, 0.1, 0.9, 1] });
     this._previewObserver.observe(this.itemDiv.nativeElement);

--- a/src/app/components/items/items.component.ts
+++ b/src/app/components/items/items.component.ts
@@ -35,6 +35,7 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
   shownItems: Array<IItem> = [];
   shownUnlocked: number = 0;
 
+  showFieldGuide = false;
   showNone = false;
   offsetNone = 0;
 
@@ -98,6 +99,10 @@ export class ItemsComponent implements AfterViewInit, OnDestroy {
 
   selectCategory(type: string) {
     this._router.navigate([], { queryParams: { type, item: this.selectedItem?.guid }, replaceUrl: true });
+  }
+
+  togglePreviews(): void {
+    this.showFieldGuide = !this.showFieldGuide;
   }
 
   private initializeItems(): void {

--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -1,4 +1,4 @@
-<aside class="scroll-hover">
+<aside>
   <nav>
     <div class="items">
       <!-- Home-->

--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -1,4 +1,4 @@
-<aside>
+<aside class="scroll-hover">
   <nav>
     <div class="items">
       <!-- Home-->

--- a/src/app/components/realm/realm.component.html
+++ b/src/app/components/realm/realm.component.html
@@ -4,10 +4,7 @@
   </div>
   <div class="sky-card-body">
     <div class="grid grid-2">
-      <a class="container colspan-2" *ngIf="realm._wiki?.href" target="_blank" [href]="realm._wiki?.href">
-        <mat-icon class="menu-icon">question_mark</mat-icon>
-        <span class="menu-label">Wiki</span>
-      </a>
+      <app-wiki-link [wiki]="realm._wiki" [aClass]="'container colspan-2'"></app-wiki-link>
       <a class="container" *ngIf="spirits.length" [class.colspan-2]="!seasonSpiritCount" [routerLink]="['/spirit']" [queryParams]="{ type: 'Regular,Elder', realm: realm.guid }">
         <app-spirit-type-icon class="menu-icon" [type]="'Regular'"></app-spirit-type-icon>
         <span class="menu-label">

--- a/src/app/components/realms/realms.component.html
+++ b/src/app/components/realms/realms.component.html
@@ -3,10 +3,7 @@
     <h1 class="h2 mb-0">Realms</h1>
   </div>
   <div class="sky-card-body">
-    <a class="container d-inline-block" href="https://sky-children-of-the-light.fandom.com/wiki/Realms" target="_blank">
-      <mat-icon class="menu-icon">question_mark</mat-icon>
-      <span class="menu-label">Wiki</span>
-    </a>
+    <app-wiki-link [wiki]="{href: 'https://sky-children-of-the-light.fandom.com/wiki/Realms'}"></app-wiki-link>
   </div>
 </div>
 

--- a/src/app/components/returning-spirit/returning-spirit.component.html
+++ b/src/app/components/returning-spirit/returning-spirit.component.html
@@ -5,12 +5,7 @@
   <div class="sky-card-body">
     <div class="grid grid-2">
       <!-- Wiki-->
-      <a class="container colspan-2" *ngIf="rs._wiki?.href" [href]="rs._wiki?.href" target="_blank">
-        <mat-icon class="menu-icon">question_mark</mat-icon>
-        <span class="menu-label">
-          <span>Wiki</span>
-        </span>
-      </a>
+      <app-wiki-link [wiki]="rs._wiki" [aClass]="'container colspan-2'"></app-wiki-link>
       <!-- Date -->
       <div class="container" [class.expired]="state === 'ended'">
         <mat-icon class="menu-icon">calendar_month</mat-icon>

--- a/src/app/components/returning-spirits/returning-spirits.component.html
+++ b/src/app/components/returning-spirits/returning-spirits.component.html
@@ -3,10 +3,7 @@
     <h1 class="h2 mb-0">Special Visits</h1>
   </div>
   <div class="sky-card-body">
-    <a class="container d-inline-block" href="https://sky-children-of-the-light.fandom.com/wiki/Returning_Spirits" target="_blank">
-      <mat-icon class="menu-icon">question_mark</mat-icon>
-      <span class="menu-label">Wiki</span>
-    </a>
+    <app-wiki-link [wiki]="{href: 'https://sky-children-of-the-light.fandom.com/wiki/Returning_Spirits'}"></app-wiki-link>
   </div>
 </div>
 

--- a/src/app/components/season/season.component.html
+++ b/src/app/components/season/season.component.html
@@ -5,12 +5,7 @@
   <div class="sky-card-body">
     <div class="grid grid-2">
       <!-- Wiki -->
-      <a class="container" *ngIf="season._wiki?.href" [href]="season._wiki?.href" target="_blank">
-        <mat-icon class="menu-icon">question_mark</mat-icon>
-        <span class="menu-label">
-          Wiki
-        </span>
-      </a>
+      <app-wiki-link [wiki]="season._wiki" [aClass]="'container'"></app-wiki-link>
       <!-- Spirits -->
       <a class="container" [routerLink]="'/spirit'" [queryParams]="{ season: season.guid, type: 'Season,Guide' }">
         <mat-icon class="menu-icon">list</mat-icon>

--- a/src/app/components/seasons/seasons.component.html
+++ b/src/app/components/seasons/seasons.component.html
@@ -3,10 +3,7 @@
     <h1 class="h2">Seasons</h1>
   </div>
   <div class="sky-card-body">
-    <a class="container d-inline-block" href="https://sky-children-of-the-light.fandom.com/wiki/Seasonal_Events" target="_blank">
-      <mat-icon class="menu-icon">question_mark</mat-icon>
-      <span class="menu-label">Wiki</span>
-    </a>
+    <app-wiki-link [wiki]="{href: 'https://sky-children-of-the-light.fandom.com/wiki/Seasonal_Events'}"></app-wiki-link>
     <div class="flex mt">
       <a class="item-icon" *ngFor="let season of reverseSeasons"
         [routerLink]="['/season', season.guid]"

--- a/src/app/components/seasons/seasons.component.html
+++ b/src/app/components/seasons/seasons.component.html
@@ -8,7 +8,7 @@
       <span class="menu-label">Wiki</span>
     </a>
     <div class="flex mt">
-      <a class="flex-item" *ngFor="let season of reverseSeasons"
+      <a class="item-icon" *ngFor="let season of reverseSeasons"
         [routerLink]="['/season', season.guid]"
         [ngbTooltip]="season.name" placement="bottom" container="body">
         <img class="season-icon" [src]="season.iconUrl" />

--- a/src/app/components/seasons/seasons.component.less
+++ b/src/app/components/seasons/seasons.component.less
@@ -16,3 +16,11 @@
   background-position: center;
   background-size: 100%;
 }
+
+.item-icon {
+  position: relative;
+  width: var(--item-size);
+  height: var(--item-size);
+  background: var(--color-background);
+  border-radius: var(--border-radius)
+}

--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -75,4 +75,17 @@
       </div>
     </div>
   </div>
+
+  <!-- Wiki -->
+  <div class="sky-card mt">
+    <div class="sky-card-header">
+      <h2 class="h3">Wiki</h2>
+    </div>
+    <div class="sky-card-body">
+      <div class="container wiki-toggle-tab" (click)="toggleWikiTab()">
+        <mat-icon class="menu-icon">{{wikiNewTab ? 'check_box' : 'check_box_outline_blank'}}</mat-icon>
+        <span class="menu-label">Navigate to wiki in new tab</span>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/components/settings/settings.component.less
+++ b/src/app/components/settings/settings.component.less
@@ -13,3 +13,10 @@
   color: #fff !important;
   background: #50b6d8 !important;
 }
+
+.wiki-toggle-tab {
+  cursor: pointer;
+  &:hover {
+    color: var(--color-link-hover);
+  }
+}

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -4,6 +4,7 @@ import { StorageService } from 'src/app/services/storage.service';
 import { ThemeService } from 'src/app/services/theme.service';
 import { DataService } from 'src/app/services/data.service';
 import { DateHelper } from 'src/app/helpers/date-helper';
+import { SettingService } from 'src/app/services/setting.service';
 
 @Component({
   selector: 'app-settings',
@@ -17,8 +18,11 @@ export class SettingsComponent {
   dateFormats: Array<string>;
   currentTheme: string;
 
+  wikiNewTab = false;
+
   constructor(
     private readonly _dataService: DataService,
+    private readonly _settingService: SettingService,
     private readonly _storageService: StorageService,
     private readonly _themeService: ThemeService
   ) {
@@ -26,6 +30,7 @@ export class SettingsComponent {
     this.dateFormats = DateHelper.displayFormats;
     this.dateFormat = DateHelper.displayFormat;
     this.currentTheme = this._themeService.theme || 'sky';
+    this.wikiNewTab = _settingService.wikiNewTab;
   }
 
   export(): void {
@@ -110,5 +115,10 @@ export class SettingsComponent {
     this.dateFormat = format;
     DateHelper.displayFormat = format;
     localStorage.setItem('date.format', format);
+  }
+
+  toggleWikiTab(): void {
+    this.wikiNewTab = !this.wikiNewTab;
+    this._settingService.wikiNewTab = this.wikiNewTab;
   }
 }

--- a/src/app/components/shops/shops.component.html
+++ b/src/app/components/shops/shops.component.html
@@ -3,10 +3,7 @@
     <h1 class="h2 mb-0">Permanent In-App Purchases</h1>
   </div>
   <div class="sky-card-body">
-    <a class="container d-inline-block" href="https://sky-children-of-the-light.fandom.com/wiki/Premium_Candle_Shop" target="_blank">
-      <mat-icon class="menu-icon">question_mark</mat-icon>
-      <span class="menu-label">Wiki</span>
-    </a>
+    <app-wiki-link [wiki]="{href: 'https://sky-children-of-the-light.fandom.com/wiki/Premium_Candle_Shop'}"></app-wiki-link>
   </div>
 </div>
 

--- a/src/app/components/spirit-card/spirit-card.component.html
+++ b/src/app/components/spirit-card/spirit-card.component.html
@@ -37,12 +37,7 @@
         </span>
       </div>
       <!-- Wiki -->
-      <a *ngIf="sections['wiki'] && spirit._wiki?.href" [href]="spirit._wiki!.href" target="_blank"
-        class="spirit-grid-item sky-card-item sky-card-item-icon" [style.order]="sections['wiki']"
-      >
-        <mat-icon>question_mark</mat-icon>
-        <span class="menu-label">Wiki</span>
-      </a>
+      <app-wiki-link *ngIf="sections['wiki']" [wiki]="spirit._wiki" [aClass]="'spirit-grid-item sky-card-item sky-card-item-icon'" [order]="sections['wiki']"></app-wiki-link>
       <!-- Season -->
       <a *ngIf="sections['season'] && (spirit.type === 'Season' || spirit.type === 'Guide')" [routerLink]="['/season', spirit.season?.guid]" [queryParams]="{ highlightTree: spirit.tree?.guid }"
         class="spirit-grid-item sky-card-item sky-card-item-icon" [style.order]="sections['season']"

--- a/src/app/components/spirit/spirit.component.html
+++ b/src/app/components/spirit/spirit.component.html
@@ -20,10 +20,7 @@
         </div>
       </div>
       <!-- 1: Wiki -->
-      <a class="spirit-grid-item sky-card-item sky-card-item-icon" *ngIf="spirit._wiki?.href" [href]="spirit._wiki!.href" target="_blank">
-        <mat-icon>question_mark</mat-icon>
-        <span class="menu-label">Wiki</span>
-      </a>
+      <app-wiki-link [wiki]="spirit._wiki" [aClass]="'spirit-grid-item sky-card-item sky-card-item-icon'"></app-wiki-link>
       <!-- 2: Season -->
       <a class="spirit-grid-item sky-card-item sky-card-item-icon" *ngIf="spirit.type === 'Season' || spirit.type === 'Guide'" [routerLink]="['/season', spirit.season?.guid]" [queryParams]="{ highlightTree: spirit.tree?.guid }">
         <img *ngIf="spirit.season?.iconUrl; else seasonIcon" [src]="spirit.season!.iconUrl" class="icon">

--- a/src/app/components/traveling-spirits/traveling-spirits.component.html
+++ b/src/app/components/traveling-spirits/traveling-spirits.component.html
@@ -3,10 +3,7 @@
     <h1 class="h2 mb-0">Traveling Spirits</h1>
   </div>
   <div class="sky-card-body">
-    <a class="container d-inline-block" href="https://sky-children-of-the-light.fandom.com/wiki/Traveling_Spirits" target="_blank">
-      <mat-icon class="menu-icon">question_mark</mat-icon>
-      <span class="menu-label">Wiki</span>
-    </a>
+    <app-wiki-link [wiki]="{href: 'https://sky-children-of-the-light.fandom.com/wiki/Traveling_Spirits'}"></app-wiki-link>
   </div>
 </div>
 

--- a/src/app/components/util/wiki-link/wiki-link.component.html
+++ b/src/app/components/util/wiki-link/wiki-link.component.html
@@ -1,0 +1,6 @@
+<ng-container *ngIf="wiki">
+  <a [class]="aClass" [href]="wiki.href || '#'" [attr.target]="openNewTab ? '_blank' : undefined" [style.order]="order">
+    <mat-icon class="menu-icon">question_mark</mat-icon>
+    <span class="menu-label">Wiki</span>
+  </a>
+</ng-container>

--- a/src/app/components/util/wiki-link/wiki-link.component.less
+++ b/src/app/components/util/wiki-link/wiki-link.component.less
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/src/app/components/util/wiki-link/wiki-link.component.ts
+++ b/src/app/components/util/wiki-link/wiki-link.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { IWiki } from 'src/app/interfaces/wiki.interface';
+import { SettingService } from 'src/app/services/setting.service';
+
+@Component({
+  selector: 'app-wiki-link',
+  templateUrl: './wiki-link.component.html',
+  styleUrls: ['./wiki-link.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WikiLinkComponent {
+  @Input() aClass? = 'container d-inline-block';
+  @Input() wiki?: IWiki;
+  @Input() order?: number;
+
+  openNewTab = false;
+
+  constructor(
+    private readonly _settingService: SettingService
+  ) {
+    this.openNewTab = _settingService._wikiNewTab;
+  }
+}

--- a/src/app/components/wing-buffs/wing-buffs.component.html
+++ b/src/app/components/wing-buffs/wing-buffs.component.html
@@ -4,10 +4,7 @@
     <h1 class="h2 mb-0">Wing Buffs</h1>
   </div>
   <div class="sky-card-body">
-    <a class="container d-inline-block" href="https://sky-children-of-the-light.fandom.com/wiki/Wing_Buffs" target="_blank">
-      <mat-icon class="menu-icon">question_mark</mat-icon>
-      <span class="menu-label">Wiki</span>
-    </a>
+    <app-wiki-link [wiki]="{href: 'https://sky-children-of-the-light.fandom.com/wiki/Wing_Buffs'}"></app-wiki-link>
   </div>
 </div>
 

--- a/src/app/helpers/navigation-helper.ts
+++ b/src/app/helpers/navigation-helper.ts
@@ -1,4 +1,4 @@
-import { NavigationExtras } from '@angular/router';
+import { NavigationExtras, Params } from '@angular/router';
 import { NodeHelper } from './node-helper';
 import { IItem } from '../interfaces/item.interface';
 import dayjs, { Dayjs } from 'dayjs';
@@ -113,5 +113,12 @@ export class NavigationHelper {
       : item.type === 'Prop' ? 'Placeable_Props_Display' : 'Display';
 
     return url.toString();
+  }
+
+  static getQueryParams(href: string | URL): Params {
+    const url = href instanceof URL ? href : new URL(href);
+    const params: Params = {};
+    for (const [k,v] of url.searchParams.entries()) { params[k] = v; }
+    return params;
   }
 }

--- a/src/app/interfaces/item.interface.ts
+++ b/src/app/interfaces/item.interface.ts
@@ -14,6 +14,8 @@ export interface IItem extends IGuid {
   name: string;
   /** Path to item icon. */
   icon?: string;
+  /** Path to preview image. */
+  previewUrl?: string;
   /** Item order (within category). */
   order?: number;
 

--- a/src/app/interfaces/item.interface.ts
+++ b/src/app/interfaces/item.interface.ts
@@ -2,6 +2,7 @@ import { IConfig, IGuid } from './base.interface';
 import { IIAP } from './iap.interface';
 import { INode } from './node.interface';
 import { ISeason } from './season.interface';
+import { IWiki } from './wiki.interface';
 
 export interface IItemConfig extends IConfig<IItem> {}
 
@@ -35,6 +36,8 @@ export interface IItem extends IGuid {
 
   /// Progress ///
   unlocked?: boolean;
+
+  _wiki?: IWiki;
 }
 
 export enum ItemType {

--- a/src/app/services/setting.service.ts
+++ b/src/app/services/setting.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SettingService {
+  readonly settingChanged = new Subject<void>();
+
+  _wikiNewTab = false;
+
+  constructor() {
+    this._wikiNewTab = this.wikiNewTab;
+  }
+
+  get wikiNewTab(): boolean {
+    return localStorage.getItem('wiki.newtab') === '1';
+  }
+
+  set wikiNewTab(value: boolean) {
+    this._wikiNewTab = value;
+    localStorage.setItem('wiki.newtab', value ? '1': '0');
+    this.settingChanged.next();
+  }
+}

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -16,6 +16,8 @@
       "type": "Mask",
       "name": "Base Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Icon_mask_default.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/Mask01-no_mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Masks#Base_Mask" },
       "unlocked": true,
       "order": 1
     },
@@ -483,6 +485,8 @@
       "type": "Mask",
       "name": "Waving Bellmaker Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/WavingBellmaker-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/Mask03.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Waving_Bellmaker#Mask" },
       "order": 51
     },
     {
@@ -945,6 +949,8 @@
       "type": "Mask",
       "name": "Hide'n'Seek Pioneer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b1/HideNSeekPioneer-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/Mask06-small-chibi.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hide%27n%27Seek_Pioneer#Mask" },
       "order": 2
     },
     {
@@ -1709,6 +1715,8 @@
       "type": "Mask",
       "name": "Proud Victor Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/ProudVictor-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Mask07-No_Face.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Proud_Victor#Mask" },
       "order": 99999
     },
     {
@@ -1860,7 +1868,9 @@
       "type": "Mask",
       "name": "Fainting Warrior Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/FaintingWarrior-3.png",
-      "order": 10301
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Mask10-Full.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Fainting_Warrior#Mask" },
+      "order": 75
     },
     // Courageous Soldier
     {
@@ -2551,6 +2561,8 @@
       "group": "Ultimate",
       "name": "Gratitude Ultimate Deer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Icon_mask_gratitude_ult_deer.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Mask20-Seasonal_SoG_2019.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Gratitude_Guide#Ultimate_Gifts" },
       "order": 105
     },
     // #endregion
@@ -2605,6 +2617,8 @@
       "group": "Ultimate",
       "name": "Rhythm Ultimate Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/08/Icon_mask_rhythm_ult.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Season_of_rhythm_mask_ultimate_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rhythm_Guide#Ultimate_Gifts" },
       "order": 401
     },
     {
@@ -2847,6 +2861,8 @@
       "group": "Ultimate",
       "name": "Prophecy Ultimate Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/83/Icon_mask_prophecy_ult.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/Prophecy-Guide_Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophecy_Guide#Ultimate_Gifts" },
       "order": 705
     },
     {
@@ -2919,6 +2935,8 @@
       "group": "Ultimate",
       "name": "Dreams Ultimate Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bd/Icon_mask_dreams_ult.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/09/Dreams_mask_ultimate_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dreams_Guide#Ultimate_Gifts" },
       "order": 804
     },
     {
@@ -3011,6 +3029,8 @@
       "group": "Ultimate",
       "name": "Assembly Ultimate Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/Icon_mask_assembly_ult.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Assembly_mask_ultimate_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Ultimate_Gifts" },
       "order": 901
     },
     {
@@ -3400,6 +3420,8 @@
       "type": "Mask",
       "name": "Abyss Ultimate Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4d/SOAbyss-Ultime-gift-underwater-mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/SOAbyss-Ultime-gift-underwater-mask-screenshot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Abyss_Guide#Ultimate_Gifts" },
       "order": 1204
     },
     {
@@ -3467,6 +3489,8 @@
       "type": "Mask",
       "name": "Abyss Guide Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e6/SOAbyss-additional-mask-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/SOAbyss-mask2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Abyss_Guide#Mask" },
       "order": 1205
     },
     // #endregion
@@ -3490,6 +3514,8 @@
       "type": "Mask",
       "name": "Performance Ultimate Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/95/SOPerformance-ultimate-mask-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/67/SOP-Ultimate-guide-mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Performance_Guide#Ultimate_Gifts" },
       "order": 1301
     },
     {
@@ -3541,6 +3567,8 @@
       "type": "Mask",
       "name": "Performance Guide Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/Morybel-0146-SOPerformance-ultimate-mask-icon-f2p.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/SOPerformance-ultimate-mask-f2p.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Performance_Guide#Mask" },
       "order": 1304
     },
     {
@@ -3920,6 +3948,8 @@
       "type": "Mask",
       "name": "Cure for Me Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/SoAurora-Additional-Mask-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a1/SoAURORA-Cure-for-me-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Mask" },
       "order": 1505
     },
     // #endregion
@@ -4144,6 +4174,8 @@
       "type": "Mask",
       "name": "Passage Serow Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/Passage-additional-mask-Serow-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Passage-additional-mask-Serow.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Passage_Guide#Serow_Mask" },
       "order": 1702
     },
     {
@@ -4163,6 +4195,8 @@
       "type": "Mask",
       "name": "Passage Boar Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/96/Passage-additional-mask-Boar-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/Passage-additional-mask-Boar.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Passage_Guide#Boar_Mask" },
       "order": 1703
     },
     {
@@ -4188,6 +4222,8 @@
       "type": "Mask",
       "name": "Passage Monkey Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/48/Passage-additional-mask-Monkey-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0b/Passage-additional-mask-Monkey.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Passage_Guide#Monkey_Mask" },
       "order": 1705
     },
     {
@@ -4206,8 +4242,10 @@
     {
       "guid": "9mhT-2bV4K",
       "type": "Mask",
-      "name": "Pasasge Racoon Mask",
+      "name": "Pasasge Raccoon Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Passage-additional-mask-Racoon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4a/Passage-additional-mask-Racoon.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Passage_Guide#Raccoon_Mask" },
       "order": 1704
     },
     // Passage Ultimates
@@ -4224,6 +4262,8 @@
       "type": "Mask",
       "name": "Passage Ultimate Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bc/Passage-Ultimate-Guide-Mask-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e7/Passage-Ultimate-Guide-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Passage_Guide#Ultimate_Gifts" },
       "order": 1701
     },
     {
@@ -4383,6 +4423,8 @@
       "type": "Mask",
       "name": "Sassy Drifter Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/62/Mimi-4117_02_sassy_drifter_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/SoG2-2019_Cat_Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sassy_Drifter#Mask" },
       "order": 106
     },
     {
@@ -4520,6 +4562,8 @@
       "type": "Mask",
       "name": "Provoking Performer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/28/Mimi-4117_02_provoking_performer_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/Mask18-Seasonal_SoG_2019.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Provoking_Performer#Mask" },
       "order": 101
     },
     {
@@ -4594,6 +4638,8 @@
       "type": "Mask",
       "name": "Leaping Dancer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/Mimi-4117_02_leaping_dancer_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/Mask19-Seasonal_SoG_2019.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Leaping_Dancer#Mask" },
       "order": 102
     },
     {
@@ -4663,6 +4709,8 @@
       "type": "Mask",
       "name": "Saluting Protector Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/43/Mimi-4117_02_saluting_protector_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/eb/Mask17-Seasonal_SoG_2019.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Protector#Mask" },
       "order": 103
     },
     {
@@ -4737,6 +4785,8 @@
       "type": "Mask",
       "name": "Greeting Shaman Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/Mimi-4117_02_greeting_shaman_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/Mask16-Seasonal_SoG_2019.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Greeting_Shaman#Mask" },
       "order": 104
     },
     {
@@ -4766,6 +4816,8 @@
       "type": "Mask",
       "name": "Piggyback Lightseeker Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/29/Mimi-4117_03_piggyback_lightseeker_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Lightseekers_mask_isle_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Piggyback_Lightseeker#Mask" },
       "order": 201
     },
     {
@@ -4839,6 +4891,8 @@
       "type": "Mask",
       "name": "Doublefive Light Catcher Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/Mimi-4117_03_doublefive_light_catcher_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/Lightseekers_mask_prairie_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Doublefive_Light_Catcher#Mask" },
       "order": 202
     },
     {
@@ -4886,6 +4940,8 @@
       "type": "Mask",
       "name": "Laidback Pioneer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6a/Mimi-4117_03_laidback_pioneer_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Lightseekers_mask_forest_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laidback_Pioneer#Mask" },
       "order": 203
     },
     {
@@ -4972,6 +5028,8 @@
       "type": "Mask",
       "name": "Twirling Champion Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/43/Mimi-4117_03_twirling_champion_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Lightseekers_mask_valley_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Twirling_Champion#Mask" },
       "order": 204
     },
     {
@@ -5033,6 +5091,8 @@
       "type": "Mask",
       "name": "Crab Whisperer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e5/Mimi-4117_03_crab_whisperer_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/28/Lightseekers_mask_wasteland_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Whisperer#Mask" },
       "order": 205
     },
     {
@@ -5126,6 +5186,8 @@
       "type": "Mask",
       "name": "Shushing Light Scholar Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Mimi-4117_03_shushing_light_scholar_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/Lightseekers_mask_vault_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shushing_Light_Scholar#Mask" },
       "order": 206
     },
     {
@@ -5296,6 +5358,8 @@
       "type": "Mask",
       "name": "Boogie Kid Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e6/Mimi-4117_04_boogie_kid_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ee/Belonging_Mask_Isle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Boogie_Kid#Mask" },
       "order": 301
     },
     {
@@ -5358,6 +5422,8 @@
       "type": "Mask",
       "name": "Sparkler Parent Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b5/Mimi-4117_04_sparkler_parent_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Belonging_Mask_Valley.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sparkler_Parent#Mask" },
       "order": 304
     },
     {
@@ -5456,6 +5522,8 @@
       "type": "Mask",
       "name": "Wise Grandparent Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/39/Mimi-4117_04_wise_grandparent_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/48/Belonging_Mask_Vault.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wise_Grandparent#Mask" },
       "order": 302
     },
     {
@@ -5550,6 +5618,8 @@
       "type": "Mask",
       "name": "Pleaful Parent Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6d/Mimi-4117_04_pleaful_parent_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/eb/Belonging_Mask_Wasteland.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleaful_Parent#Mask" },
       "order": 303
     },
     {
@@ -5711,6 +5781,8 @@
       "type": "Mask",
       "name": "Troupe Greeter Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/Mimi-4117_05_troupe_greeter_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/71/Season_of_rhythm_mask_isle_welcome_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Greeter#Mask" },
       "order": 402
     },
     {
@@ -5907,6 +5979,8 @@
       "type": "Mask",
       "name": "Admiring Actor Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/70/Mimi-4117_05_admiring_actor_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d1/Season_of_rhythm_mask_forest_kisses_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Admiring_Actor#Mask" },
       "order": 403
     },
     {
@@ -6090,6 +6164,8 @@
       "type": "Mask",
       "name": "Respectful Pianist Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c7/Mimi-4117_05_respectful_pianist_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e4/Season_of_rhythm_mask_wasteland_respect_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Respectful_Pianist#Mask" },
       "order": 405
     },
     {
@@ -6143,6 +6219,8 @@
       "type": "Mask",
       "name": "Thoughtful Director Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/34/Mimi-4117_05_thoughtful_director_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/03/Season_of_rhythm_mask_vault_think_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Thoughtful_Director#Mask" },
       "order": 404
     },
     {
@@ -6226,6 +6304,8 @@
       "type": "Mask",
       "name": "Nodding Muralist Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Mimi-4117_06_nodding_muralist_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Season_of_enchantment_mask_nodding_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nodding_Muralist#Mask" },
       "order": 501
     },
     {
@@ -6306,6 +6386,8 @@
       "type": "Mask",
       "name": "Indifferent Alchemist Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/06/Mimi-4117_06_indifferent_alchemist_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/38/Season_of_enchantment_mask_indifferent_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Indifferent_Alchemist#Mask" },
       "order": 503
     },
     {
@@ -6467,6 +6549,8 @@
       "type": "Mask",
       "name": "Scarecrow Farmer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/Mimi-4117_06_scarecrow_farmer_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/04/Season_of_enchantment_mask_scare_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scarecrow_Farmer#Mask" },
       "order": 504
     },
     {
@@ -6607,6 +6691,8 @@
       "type": "Mask",
       "name": "Playfighting Herbalist Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Mimi-4117_06_playfighting_herbalist_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/ce/Season_of_enchantment_mask_playfight_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Mask" },
       "order": 502
     },
     {
@@ -6924,6 +7010,8 @@
       "type": "Mask",
       "name": "Hiking Grouch Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Mimi-4117_07_hiking_grouch_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Season_of_sanctuary_mask_grouch_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Mask" },
       "order": 602
     },
     {
@@ -7222,6 +7310,8 @@
       "type": "Mask",
       "name": "Prophet of Water Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Mimi-4117_08_prophet_of_water_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ea/Prophecy-Prophet_of_Water_Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Water#Mask" },
       "order": 701
     },
     {
@@ -7323,6 +7413,8 @@
       "type": "Mask",
       "name": "Prophet of Earth Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/50/Mimi-4117_08_prophet_of_earth_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Prophecy-Prophet_of_Earth_Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Earth#Mask" },
       "order": 702
     },
     {
@@ -7410,6 +7502,8 @@
       "type": "Mask",
       "name": "Prophet of Air Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e2/Mimi-4117_08_prophet_of_air_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4a/Prophecy-Prophet_of_Air_Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Air#Mask" },
       "order": 703
     },
     {
@@ -7511,6 +7605,8 @@
       "type": "Mask",
       "name": "Prophet of Fire Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/30/Mimi-4117_08_prophet_of_fire_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Prophecy-Prophet_of_Fire_Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Mask" },
       "order": 704
     },
     {
@@ -7691,6 +7787,8 @@
       "type": "Mask",
       "name": "Dancing Performer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/Icon_mask_dreams_dancing.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/64/Dreams_mask_dancing_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dancing_Performer#Mask" },
       "order": 802
     },
     {
@@ -7783,6 +7881,8 @@
       "type": "Mask",
       "name": "Peeking Postman Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Icon_mask_dreams_peeking.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/Dreams_mask_peeking_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Peeking_Postman#Mask" },
       "order": 801
     },
     {
@@ -7851,6 +7951,8 @@
       "type": "Mask",
       "name": "Spinning Mentor Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/69/Icon_mask_dreams_spinning.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/Dreams_mask_spinning_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Spinning_Mentor#Mask" },
       "order": 803
     },
     {
@@ -7940,6 +8042,8 @@
       "type": "Mask",
       "name": "Baffled Botanist Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Icon_mask_assembly_baffled.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Assembly_mask_baffled_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Baffled_Botanist#Mask" },
       "order": 906
     },
     {
@@ -8000,6 +8104,8 @@
       "type": "Mask",
       "name": "Scolding Student Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Icon_mask_assembly_scold.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Assembly_mask_scolding_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scolding_Student#Mask" },
       "order": 905
     },
     {
@@ -8087,6 +8193,8 @@
       "type": "Mask",
       "name": "Scaredy Cadet Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Icon_mask_assembly_scared.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/Assembly_mask_scaredy_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scaredy_Cadet#Mask" },
       "order": 907
     },
     {
@@ -8208,6 +8316,8 @@
       "type": "Mask",
       "name": "Marching Adventurer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/59/Icon_mask_assembly_march.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/Assembly_mask_marching_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Marching_Adventurer#Mask" },
       "order": 902
     },
     {
@@ -8262,6 +8372,8 @@
       "type": "Mask",
       "name": "Chuckling Scout Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/30/Icon_mask_assembly_chuckle.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e0/Assembly_mask_chuckling_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Mask" },
       "order": 903
     },
     {
@@ -8305,7 +8417,7 @@
       "name": "Chuckling Scout Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/Chuckling-Scout-shoes-icon-Credit-Morybel.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/36/Chuckling-Scout-shoes.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Shoes" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Outfit" },
       "order": 1
     },
     {
@@ -8360,6 +8472,8 @@
       "type": "Mask",
       "name": "Daydream Forester Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/Icon_mask_assembly_daydream.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/06/Assembly_mask_daydream_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Daydream_Forester#Mask" },
       "order": 904
     },
     {
@@ -8476,6 +8590,8 @@
       "type": "Mask",
       "name": "Beckoning Ruler Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/68/Icon_mask_prince_king.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ac/Season_of_little_prince_mask1.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Beckoning_Ruler#Mask" },
       "order": 1001
     },
     {
@@ -9277,6 +9393,8 @@
       "type": "Mask",
       "name": "Anxious Angler Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/SOAbyss-Anxious-Angler-mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/61/SOAbyss-Anxious-Angler-mask-screenshot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Anxious_Angler#Mask" },
       "order": 1206
     },
     {
@@ -9374,6 +9492,8 @@
       "type": "Mask",
       "name": "Ceasing Commodore Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/SOAbyss-Ceasing-Commodore-mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/SOAbyss-Ceasing-Commodore-mask-screenshot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ceasing_Commodore#Mask" },
       "order": 1202
     },
     {
@@ -9442,6 +9562,8 @@
       "type": "Mask",
       "name": "Bumbling Boatswain Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/04/SOAbyss-Bumbling-Boatswain-mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/SOAbyss-Bumbling-Boatswain-mask-screenshot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bumbling_Boatswain#Mask" },
       "order": 1201
     },
     {
@@ -9537,6 +9659,8 @@
       "type": "Mask",
       "name": "Cackling Cannoneer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/SOAbyss-Cackling-Cannoneer-mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/ff/SOAbyss-Cackling-Cannoneer-mask-screenshot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cackling_Cannoneer#Mask" },
       "order": 1203
     },
     {
@@ -9663,6 +9787,8 @@
       "type": "Mask",
       "name": "Frantic Stagehand Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f4/SoPerformance_-_Frantic_Stagehand-mask-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/SoPerformance_-_Frantic_Stagehand-mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frantic_Stagehand#Mask" },
       "order": 1303
     },
     {
@@ -9707,6 +9833,8 @@
       "type": "Mask",
       "name": "Forgetful Storyteller Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/SoPerformance_-_Forgetful_Storyteller-mask-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/SoPerformance_-_Forgetful_Storyteller-mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forgetful_Storyteller#Mask" },
       "order": 1305
     },
     {
@@ -9791,6 +9919,8 @@
       "type": "Mask",
       "name": "Mellow Musician Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/Morybel-0146-SoPerformance_-_Mellow_Musician-mask-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Performance_-_Mellow_Musician-mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mellow_Musician#Mask" },
       "order": 1306
     },
     {
@@ -9884,6 +10014,8 @@
       "type": "Mask",
       "name": "Modest Dancer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a4/SOPerformance-Modest-Dancer-maks-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c7/SOPerformance-Modest-Dancer-_Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Modest_Dancer#Mask" },
       "order": 1302
     },
     {
@@ -10061,6 +10193,8 @@
       "type": "Mask",
       "name": "Darkness Plant Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/33/SOShattering-Dark-Mask-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/SOShattering-Dark-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Darkness#Mask" },
       "order": 1401
     },
     {
@@ -10164,6 +10298,8 @@
       "type": "Mask",
       "name": "Running Wayfarer Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/SoAurora-Running-Wayfarer-Mask-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/SoAurora-Running-Wayfarer-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Running_Wayfarer#Mask" },
       "order": 1502
     },
     {
@@ -10259,6 +10395,8 @@
       "type": "Mask",
       "name": "Mindful Miner Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bc/SoAurora-Mindful-Miner-Mask-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f3/SoAurora-Mindful-Miner-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mindful_Miner#Mask" },
       "order": 1504
     },
     {
@@ -10344,6 +10482,8 @@
       "type": "Mask",
       "name": "Warrior of Love Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b5/SoAurora-Warrior-of-Love-Mask-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/59/SoAurora-Warrior-of-Love-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Warrior_of_Love#Mask" },
       "order": 1503
     },
     {
@@ -10439,6 +10579,8 @@
       "type": "Mask",
       "name": "Seed of Hope Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/76/SoAurora-Seed-of-Hope-Mask-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bd/SoAurora-Seed-of-Hope-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Seed_of_Hope#Mask" },
       "order": 1501
     },
     {
@@ -10602,6 +10744,8 @@
       "type": "Mask",
       "name": "Bereft Veteran Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/00/SoRemembrance-Bereft-Veteran-Mask-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/SoRemembrance-Bereft-Veteran-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bereft_Veteran#Mask" },
       "order": 1601
     },
     {
@@ -10838,6 +10982,8 @@
       "type": "Mask",
       "name": "Wounded Warrior Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/86/SoRemembrance-Wounded-Warrior-Mask-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d4/SoRemembrance-Wounded-Warrior-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wounded_Warrior#Mask" },
       "order": 1602
     },
     {
@@ -11215,6 +11361,8 @@
       "type": "Mask",
       "name": "Reassuring Ranger Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/91/Reassuring-Ranger-Mask-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Reassuring-Ranger-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Reassuring_Ranger#Mask" },
       "order": 1801
     },
     {
@@ -11358,6 +11506,8 @@
       "type": "Mask",
       "name": "Ascetic Monk Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1f/Ascetic-Monk-Mask-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/ba/Ascetic-Monk-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ascetic_Monk#Mask" },
       "order": 1802
     },
     {
@@ -11487,7 +11637,9 @@
       "type": "Mask",
       "name": "Days of Fortune Bull Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/ce/Icon_mask_ox.png",
-      "order": 10601
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/71/Ox_mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Bull_Mask" },
+      "order": 10201
     },
     {
       "guid": "LgDGqWw-NO",
@@ -11522,7 +11674,9 @@
       "type": "Mask",
       "name": "Days of Fortune Blushing Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Icon_mask_blush.png",
-      "order": 10401
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/Rosy_cheeks_mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Blushing_Mask" },
+      "order": 10101
     },
     {
       "guid": "rNDDbcjS4G",
@@ -11536,7 +11690,9 @@
       "type": "Mask",
       "name": "Days of Fortune Tiger Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/07/Days_of_Fortune_-_Tiger_mask_head_icon.png",
-      "order": 10701
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/Days-of-fortune-2021-tiger-mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Tiger_Mask" },
+      "order": 10202
     },
     {
       "guid": "OjSfpOgFoR",
@@ -11580,7 +11736,9 @@
       "type": "Mask",
       "name": "Days of Fortune Rabbit Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Days-of-Fortune-Rabbit-Mask-icon-Morybel-0146.png",
-      "order": 10201
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/Days-of-Fortune-Rabbit-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Rabbit_Mask" },
+      "order": 10203
     },
     {
       "guid": "1QMUTwskc3",
@@ -11662,7 +11820,9 @@
       "type": "Mask",
       "name": "Days of Love Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b1/Icon_mask_rose.png",
-      "order": 10501
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/50/Days_of_love_rose_mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love#Days_of_Love_Mask" },
+      "order": 10401
     },
     {
       "guid": "yWCpBlHsWa",
@@ -12329,7 +12489,10 @@
       "guid": "TbSEPp5DAI",
       "name": "Style Runway Makeup Mask",
       "type": "Mask",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fc/Runway-Makeup-Mask-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fc/Runway-Makeup-Mask-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f5/Runway-Makeup-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Style#Style_Runway_Makeup_Mask" },
+      "order": 10601
     },
     {
       "guid": "TalOg0V1he",
@@ -12463,7 +12626,9 @@
       "type": "Mask",
       "name": "Cat Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Days-of-Mischief-Cat-Mask-Icon-Morybel-0146.png",
-      "order": 10901
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/12/Days-of-Mischief-Cat-Mask.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Cat_Mask" },
+      "order": 10501
     },
     {
       "guid": "pG1_D61KMT",
@@ -12986,6 +13151,8 @@
       "type": "Mask",
       "name": "Journey Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Journey-Pack-Mask-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/JourneyPack-Mask-Nastymold.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Journey_Pack" },
       "order": 20001
     },
     {

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -4,6 +4,7 @@
     {
       "guid": "EEQZwFIJRs",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Mask05-Diamond.png",
       "name": "Base Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Icon_pants_default.png",
       "unlocked": true,
@@ -119,6 +120,7 @@
     {
       "guid": "um3PQEl09a",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/Mask09.png",
       "name": "Pointing Candlemaker Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d5/PointingCandlemaker-3.png",
       "order": 6
@@ -187,6 +189,7 @@
     {
       "guid": "Vz2Gpg4FSQ",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Mask08.png",
       "name": "Ushering Stargazer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ab/UsheringStargazer-3.png",
       "order": 7
@@ -325,6 +328,7 @@
     {
       "guid": "1qBmwSZFkz",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Mask11.png",
       "name": "Butterfly Charmer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f3/ButterflyCharmer-4.png",
       "order": 5
@@ -779,6 +783,7 @@
     {
       "guid": "Y2XIZBa7Ir",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Mask12-Long_Panel.png",
       "name": "Shivering Trailblazer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/32/ShiveringTrailblazer-2.png",
       "order": 2
@@ -946,6 +951,7 @@
     {
       "guid": "bwJ7i7NrlR",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/00/Elder-Mask-Isle-original-Credit-Nastymold.png",
       "name": "Hide'n'Seek Pioneer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/HideNSeekPioneer-4.png",
       "order": 9
@@ -1330,6 +1336,7 @@
     {
       "guid": "N9G6m1vBZh",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Elder-Mask-Prairie-original-Credit-Nastymold.png",
       "name": "Confident Sightseer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/71/ConfidentSightseer-3.png",
       "order": 8
@@ -2251,6 +2258,7 @@
     {
       "guid": "wXOGyF57AN",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Elder-Mask-Forest-original-Credit-Nastymold.png",
       "name": "Memory Whisperer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a1/MemoryWhisperer-2.png",
       "order": 4
@@ -2310,6 +2318,7 @@
     {
       "guid": "3T-ZS6ZooQ",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Season_of_sanctuary_mask_chill_v2.png",
       "name": "Polite Scholar Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/68/PoliteScholar-2.png",
       "order": 3
@@ -3147,6 +3156,7 @@
     {
       "guid": "BD7KBFgGf0",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/Days-of-Feast-Yeti-Goggles.png",
       "group": "Ultimate",
       "name": "Little Prince Ultimate Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Icon_pants_prince_pjs.png",
@@ -3163,6 +3173,7 @@
     {
       "guid": "l_C7GM60an",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/89/Days-of-Nature-Glasses.png",
       "name": "Sword Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/Icon_pants_prince_sword.png",
       "order": 1002
@@ -3271,6 +3282,7 @@
     {
       "guid": "SxX0bNDJaR",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/19/Style-Star-Sunglasses.png",
       "name": "Flight Ultimate Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Icon_season_of_flight_pants_1_ult.png",
       "order": 1101
@@ -3732,6 +3744,7 @@
     {
       "guid": "kr95Zsf1Cs",
       "type": "Outfit",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Style-Flame-Sunglasses.png",
       "name": "AURORA Ultimate Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/SoAurora-Ultimate-Outfit-icon-Morybel-0146.png",
       "order": 1502

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -61,6 +61,7 @@
       "guid": "pIYsXjTR_g",
       "type": "Emote",
       "name": "Sit",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Menus_and_Controls#Sit" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/Emote-basic_sit.png",
       "unlocked": true,
@@ -74,6 +75,7 @@
       "guid": "kvjLVjWmZ9",
       "type": "Emote",
       "name": "Point",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pointing_Candlemaker#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/55/PointingCandlemaker-1.png",
       "order": 101
@@ -82,6 +84,7 @@
       "guid": "FEF2-KzQfp",
       "type": "Emote",
       "name": "Point",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pointing_Candlemaker#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/55/PointingCandlemaker-1.png"
     },
@@ -116,6 +119,7 @@
       "guid": "GAEC5m-uk9",
       "type": "Emote",
       "name": "Point",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pointing_Candlemaker#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/55/PointingCandlemaker-1.png"
     },
@@ -123,6 +127,7 @@
       "guid": "c9GTqnZ2-q",
       "type": "Emote",
       "name": "Point",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pointing_Candlemaker#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/55/PointingCandlemaker-1.png"
     },
@@ -146,6 +151,7 @@
       "guid": "qbTj75q8dk",
       "type": "Emote",
       "name": "Come",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ushering_Stargazer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/UsheringStargazer-1.png",
       "order": 111
@@ -154,6 +160,7 @@
       "guid": "9MxRR5To8o",
       "type": "Emote",
       "name": "Come",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ushering_Stargazer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/UsheringStargazer-1.png"
     },
@@ -188,6 +195,7 @@
       "guid": "C5uj1dP42Q",
       "type": "Emote",
       "name": "Come",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ushering_Stargazer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/UsheringStargazer-1.png"
     },
@@ -195,6 +203,7 @@
       "guid": "NFNgmugp6o",
       "type": "Emote",
       "name": "Come",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ushering_Stargazer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/UsheringStargazer-1.png"
     },
@@ -218,6 +227,7 @@
       "guid": "Dhhtyjsi1E",
       "type": "Emote",
       "name": "No Thanks",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rejecting_Voyager#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/RejectingVoyager-1.png",
       "order": 121
@@ -226,6 +236,7 @@
       "guid": "I101mvqSaI",
       "type": "Emote",
       "name": "No Thanks",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rejecting_Voyager#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/RejectingVoyager-1.png"
     },
@@ -260,6 +271,7 @@
       "guid": "eAWuSSOshD",
       "type": "Emote",
       "name": "No Thanks",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rejecting_Voyager#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/RejectingVoyager-1.png"
     },
@@ -267,6 +279,7 @@
       "guid": "JXgUCqaMMt",
       "type": "Emote",
       "name": "No Thanks",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rejecting_Voyager#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/RejectingVoyager-1.png"
     },
@@ -292,6 +305,7 @@
       "guid": "mCySIT_2dL",
       "type": "Emote",
       "name": "Butterfly",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Butterfly_Charmer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/ButterflyCharmer-1.png",
       "order": 161
@@ -300,6 +314,7 @@
       "guid": "UerEKNAbKh",
       "type": "Emote",
       "name": "Butterfly",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Butterfly_Charmer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/ButterflyCharmer-1.png"
     },
@@ -334,6 +349,7 @@
       "guid": "cVsVWobkgR",
       "type": "Emote",
       "name": "Butterfly",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Butterfly_Charmer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/ButterflyCharmer-1.png"
     },
@@ -341,6 +357,7 @@
       "guid": "pnigGjpTJH",
       "type": "Emote",
       "name": "Butterfly",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Butterfly_Charmer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/ButterflyCharmer-1.png"
     },
@@ -379,6 +396,7 @@
       "guid": "yU982A7Cgz",
       "type": "Emote",
       "name": "Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Applauding_Bellmaker#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/ApplaudingBellmaker-1.png",
       "order": 171
@@ -387,6 +405,7 @@
       "guid": "t0pk8Z0cui",
       "type": "Emote",
       "name": "Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Applauding_Bellmaker#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/ApplaudingBellmaker-1.png"
     },
@@ -421,6 +440,7 @@
       "guid": "LoLnYkCW63",
       "type": "Emote",
       "name": "Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Applauding_Bellmaker#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/ApplaudingBellmaker-1.png"
     },
@@ -428,6 +448,7 @@
       "guid": "fhE3mbrVkd",
       "type": "Emote",
       "name": "Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Applauding_Bellmaker#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/ApplaudingBellmaker-1.png"
     },
@@ -442,6 +463,7 @@
       "guid": "xbObJc9i-R",
       "type": "Emote",
       "name": "Wave",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Waving_Bellmaker#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/WavingBellmaker-1.png",
       "order": 181
@@ -450,6 +472,7 @@
       "guid": "VRZyKNt7QI",
       "type": "Emote",
       "name": "Wave",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Waving_Bellmaker#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/WavingBellmaker-1.png"
     },
@@ -484,6 +507,7 @@
       "guid": "Tqp9IA1cb_",
       "type": "Emote",
       "name": "Wave",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Waving_Bellmaker#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/WavingBellmaker-1.png"
     },
@@ -491,6 +515,7 @@
       "guid": "VyCFJt_BeY",
       "type": "Emote",
       "name": "Wave",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Waving_Bellmaker#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/WavingBellmaker-1.png"
     },
@@ -520,6 +545,7 @@
       "guid": "-tpjP_IITi",
       "type": "Emote",
       "name": "Yawn",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slumbering_Shipwright#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/SlumberingShipwright-1.png",
       "order": 201
@@ -528,6 +554,7 @@
       "guid": "f3IKpWrXWd",
       "type": "Emote",
       "name": "Yawn",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slumbering_Shipwright#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/SlumberingShipwright-1.png"
     },
@@ -562,6 +589,7 @@
       "guid": "1XGQKgE4NF",
       "type": "Emote",
       "name": "Yawn",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slumbering_Shipwright#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/SlumberingShipwright-1.png"
     },
@@ -569,6 +597,7 @@
       "guid": "wyhPTBmWXl",
       "type": "Emote",
       "name": "Yawn",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slumbering_Shipwright#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/SlumberingShipwright-1.png"
     },
@@ -583,6 +612,7 @@
       "guid": "hpAJ_E_MaE",
       "type": "Emote",
       "name": "Laugh",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laughing_Light_Catcher#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/LaughingLightCatcher-1.png",
       "order": 191
@@ -591,6 +621,7 @@
       "guid": "Ozy3lpnc37",
       "type": "Emote",
       "name": "Laugh",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laughing_Light_Catcher#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/LaughingLightCatcher-1.png"
     },
@@ -625,6 +656,7 @@
       "guid": "18rVAyXlim",
       "type": "Emote",
       "name": "Laugh",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laughing_Light_Catcher#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/LaughingLightCatcher-1.png"
     },
@@ -632,6 +664,7 @@
       "guid": "QgWjpddbV_",
       "type": "Emote",
       "name": "Laugh",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laughing_Light_Catcher#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/LaughingLightCatcher-1.png"
     },
@@ -703,6 +736,7 @@
       "guid": "gmpO51jsXq",
       "type": "Emote",
       "name": "Wipe Brow",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Exhausted_Dock_Worker#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/ExhaustedDockWorker-1.png",
       "order": 211
@@ -711,6 +745,7 @@
       "guid": "Z2rsK4f5ny",
       "type": "Emote",
       "name": "Wipe Brow",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Exhausted_Dock_Worker#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/ExhaustedDockWorker-1.png"
     },
@@ -736,6 +771,7 @@
       "guid": "1K-jbnXT59",
       "type": "Emote",
       "name": "Wipe Brow",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Exhausted_Dock_Worker#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/ExhaustedDockWorker-1.png"
     },
@@ -743,6 +779,7 @@
       "guid": "Zlx6n-UKQ9",
       "type": "Emote",
       "name": "Wipe Brow",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Exhausted_Dock_Worker#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/ExhaustedDockWorker-1.png"
     },
@@ -766,6 +803,7 @@
       "guid": "JSp5Simw5V",
       "type": "Emote",
       "name": "Teamwork",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ceremonial_Worshiper#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/CeremonialWorshiper-1.png",
       "order": 221
@@ -801,6 +839,7 @@
       "guid": "cg1HspRoFt",
       "type": "Emote",
       "name": "Shiver",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shivering_Trailblazer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/ShiveringTrailblazer-1.png",
       "order": 271
@@ -809,6 +848,7 @@
       "guid": "CjN1GNyRo5",
       "type": "Emote",
       "name": "Shiver",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shivering_Trailblazer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/ShiveringTrailblazer-1.png"
     },
@@ -843,6 +883,7 @@
       "guid": "zHkQGblG-B",
       "type": "Emote",
       "name": "Shiver",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shivering_Trailblazer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/ShiveringTrailblazer-1.png"
     },
@@ -850,6 +891,7 @@
       "guid": "WKFJkGzYdl",
       "type": "Emote",
       "name": "Shiver",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shivering_Trailblazer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/ShiveringTrailblazer-1.png"
     },
@@ -873,6 +915,7 @@
       "guid": "EMWqfLlCv8",
       "type": "Emote",
       "name": "Shy",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Blushing_Prospector#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/BlushingProspector-1.png",
       "order": 301
@@ -881,6 +924,7 @@
       "guid": "MPG42915f5",
       "type": "Emote",
       "name": "Shy",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Blushing_Prospector#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/BlushingProspector-1.png"
     },
@@ -915,6 +959,7 @@
       "guid": "msoi-2PV03",
       "type": "Emote",
       "name": "Shy",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Blushing_Prospector#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/BlushingProspector-1.png"
     },
@@ -922,6 +967,7 @@
       "guid": "jHWFCcLqlj",
       "type": "Emote",
       "name": "Shy",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Blushing_Prospector#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/BlushingProspector-1.png"
     },
@@ -945,6 +991,7 @@
       "guid": "iGgNmgUF3h",
       "type": "Emote",
       "name": "Hide and Seek",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hide'n'Seek_Pioneer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/HideNSeekPioneer-1.png",
       "order": 281
@@ -1011,6 +1058,7 @@
       "guid": "tNluEK79s-",
       "type": "Emote",
       "name": "Angry",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pouty_Porter#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/PoutyPorter-1.png",
       "order": 291
@@ -1019,6 +1067,7 @@
       "guid": "YkzYpoa9me",
       "type": "Emote",
       "name": "Angry",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pouty_Porter#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/PoutyPorter-1.png"
     },
@@ -1053,6 +1102,7 @@
       "guid": "FnCfXeMPEq",
       "type": "Emote",
       "name": "Angry",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pouty_Porter#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/PoutyPorter-1.png"
     },
@@ -1060,6 +1110,7 @@
       "guid": "JEKMfn1NPZ",
       "type": "Emote",
       "name": "Angry",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pouty_Porter#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/PoutyPorter-1.png"
     },
@@ -1098,6 +1149,7 @@
       "guid": "3sNvbNBB2y",
       "type": "Emote",
       "name": "Shocked",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dismayed_Hunter#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/DismayedHunter-1.png",
       "order": 311
@@ -1106,6 +1158,7 @@
       "guid": "n8IVtB9J3F",
       "type": "Emote",
       "name": "Shocked",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dismayed_Hunter#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/DismayedHunter-1.png"
     },
@@ -1140,6 +1193,7 @@
       "guid": "yxgVQg3Amb",
       "type": "Emote",
       "name": "Shocked",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dismayed_Hunter#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/DismayedHunter-1.png"
     },
@@ -1147,6 +1201,7 @@
       "guid": "E1IE_GD9iG",
       "type": "Emote",
       "name": "Shocked",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dismayed_Hunter#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/DismayedHunter-1.png"
     },
@@ -1185,6 +1240,7 @@
       "guid": "ubqUcBPT43",
       "type": "Emote",
       "name": "Apologize",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Apologetic_Lumberjack#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/23/ApologeticLumberjack-1.png",
       "order": 321
@@ -1193,6 +1249,7 @@
       "guid": "2WUjYDii5w",
       "type": "Emote",
       "name": "Apologize",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Apologetic_Lumberjack#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/23/ApologeticLumberjack-1.png"
     },
@@ -1227,6 +1284,7 @@
       "guid": "Ns5iP8sS2u",
       "type": "Emote",
       "name": "Apologize",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Apologetic_Lumberjack#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/23/ApologeticLumberjack-1.png"
     },
@@ -1234,6 +1292,7 @@
       "guid": "SFlHbJLINX",
       "type": "Emote",
       "name": "Apologize",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Apologetic_Lumberjack#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/23/ApologeticLumberjack-1.png"
     },
@@ -1257,6 +1316,7 @@
       "guid": "r1Q1s66rrI",
       "type": "Emote",
       "name": "Crying",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tearful_Light_Miner#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/TearfulLightMiner-1.png",
       "order": 331
@@ -1265,6 +1325,7 @@
       "guid": "SuEWxrvIA6",
       "type": "Emote",
       "name": "Crying",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tearful_Light_Miner#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/TearfulLightMiner-1.png"
     },
@@ -1299,6 +1360,7 @@
       "guid": "dnUcxxj6St",
       "type": "Emote",
       "name": "Crying",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tearful_Light_Miner#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/TearfulLightMiner-1.png"
     },
@@ -1306,6 +1368,7 @@
       "guid": "9AzVZZ7Too",
       "type": "Emote",
       "name": "Crying",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tearful_Light_Miner#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/TearfulLightMiner-1.png"
     },
@@ -1417,6 +1480,7 @@
       "guid": "iGODc_qPpd",
       "type": "Emote",
       "name": "Handstand",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Handstanding_Thrillseeker#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/09/HandstandingThrillseeker-1.png",
       "order": 401
@@ -1425,6 +1489,7 @@
       "guid": "SK5gSmxvBt",
       "type": "Emote",
       "name": "Handstand",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Handstanding_Thrillseeker#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/09/HandstandingThrillseeker-1.png"
     },
@@ -1450,6 +1515,7 @@
       "guid": "B5tnHt0REg",
       "type": "Emote",
       "name": "Handstand",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Handstanding_Thrillseeker#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/09/HandstandingThrillseeker-1.png"
     },
@@ -1457,6 +1523,7 @@
       "guid": "4jvgh1uZDr",
       "type": "Emote",
       "name": "Handstand",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Handstanding_Thrillseeker#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/09/HandstandingThrillseeker-1.png"
     },
@@ -1534,6 +1601,7 @@
       "guid": "S3qCWOry5Q",
       "type": "Emote",
       "name": "Backflip",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Backflipping_Champion#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/BackflippingChampion-1.png",
       "order": 411
@@ -1542,6 +1610,7 @@
       "guid": "XDvPc5hCdm",
       "type": "Emote",
       "name": "Backflip",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Backflipping_Champion#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/BackflippingChampion-1.png"
     },
@@ -1576,6 +1645,7 @@
       "guid": "VaWHh_2B2X",
       "type": "Emote",
       "name": "Backflip",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Backflipping_Champion#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/BackflippingChampion-1.png"
     },
@@ -1583,6 +1653,7 @@
       "guid": "NFnTgjfTst",
       "type": "Emote",
       "name": "Backflip",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Backflipping_Champion#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/BackflippingChampion-1.png"
     },
@@ -1606,6 +1677,7 @@
       "guid": "tL1K-hP5z-",
       "type": "Emote",
       "name": "Cheer",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cheerful_Spectator#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/CheerfulSpectator-1.png",
       "order": 431
@@ -1614,6 +1686,7 @@
       "guid": "4xvMNOz0ZB",
       "type": "Emote",
       "name": "Cheer",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cheerful_Spectator#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/CheerfulSpectator-1.png"
     },
@@ -1648,6 +1721,7 @@
       "guid": "cAgxbrsMjj",
       "type": "Emote",
       "name": "Cheer",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cheerful_Spectator#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/CheerfulSpectator-1.png"
     },
@@ -1655,6 +1729,7 @@
       "guid": "ADRONECYYY",
       "type": "Emote",
       "name": "Cheer",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cheerful_Spectator#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/CheerfulSpectator-1.png"
     },
@@ -1678,6 +1753,7 @@
       "guid": "SPPN_qj2ia",
       "type": "Emote",
       "name": "Bow",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bowing_Medalist#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/BowingMedalist-1.png",
       "order": 421
@@ -1686,6 +1762,7 @@
       "guid": "7RooNO25P9",
       "type": "Emote",
       "name": "Bow",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bowing_Medalist#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/BowingMedalist-1.png"
     },
@@ -1720,6 +1797,7 @@
       "guid": "QPVqC_FiAv",
       "type": "Emote",
       "name": "Bow",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bowing_Medalist#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/BowingMedalist-1.png"
     },
@@ -1727,6 +1805,7 @@
       "guid": "ApqdPyaCIR",
       "type": "Emote",
       "name": "Bow",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bowing_Medalist#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/BowingMedalist-1.png"
     },
@@ -1817,6 +1896,7 @@
       "guid": "K06bmAYI6z",
       "type": "Emote",
       "name": "Duck",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frightened_Refugee#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/FrightenedRefugee-1.png",
       "order": 541
@@ -1825,6 +1905,7 @@
       "guid": "4LkrX4-CoT",
       "type": "Emote",
       "name": "Duck",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frightened_Refugee#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/FrightenedRefugee-1.png"
     },
@@ -1859,6 +1940,7 @@
       "guid": "4AbpTT27m7",
       "type": "Emote",
       "name": "Duck",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frightened_Refugee#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/FrightenedRefugee-1.png"
     },
@@ -1866,6 +1948,7 @@
       "guid": "RIlfA805ts",
       "type": "Emote",
       "name": "Duck",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frightened_Refugee#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/FrightenedRefugee-1.png"
     },
@@ -1889,6 +1972,7 @@
       "guid": "-Dh2r4O_z1",
       "type": "Emote",
       "name": "Faint",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Fainting_Warrior#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/FaintingWarrior-1.png",
       "order": 551
@@ -1897,6 +1981,7 @@
       "guid": "zKMOiu2THu",
       "type": "Emote",
       "name": "Faint",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Fainting_Warrior#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/FaintingWarrior-1.png"
     },
@@ -1931,6 +2016,7 @@
       "guid": "8bW-ZgD3YH",
       "type": "Emote",
       "name": "Faint",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Fainting_Warrior#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/FaintingWarrior-1.png"
     },
@@ -1938,6 +2024,7 @@
       "guid": "qCjtnFMijN",
       "type": "Emote",
       "name": "Faint",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Fainting_Warrior#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/FaintingWarrior-1.png"
     },
@@ -2091,6 +2178,7 @@
       "guid": "g8qrVY5moU",
       "type": "Emote",
       "name": "Salute",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Captain#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/SalutingCaptain-1.png",
       "order": 581
@@ -2099,6 +2187,7 @@
       "guid": "m9AevsoO_k",
       "type": "Emote",
       "name": "Salute",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Captain#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/SalutingCaptain-1.png"
     },
@@ -2133,6 +2222,7 @@
       "guid": "JWB_UaI-Wf",
       "type": "Emote",
       "name": "Salute",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Captain#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/SalutingCaptain-1.png"
     },
@@ -2140,6 +2230,7 @@
       "guid": "wtDnbvhyij",
       "type": "Emote",
       "name": "Salute",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Captain#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/SalutingCaptain-1.png"
     },
@@ -2163,6 +2254,7 @@
       "guid": "VY2WGYV8Vx",
       "type": "Emote",
       "name": "Look Around",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lookout_Scout#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/LookoutScout-1.png",
       "order": 571
@@ -2171,6 +2263,7 @@
       "guid": "dH24Ov55wg",
       "type": "Emote",
       "name": "Look Around",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lookout_Scout#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/LookoutScout-1.png"
     },
@@ -2205,6 +2298,7 @@
       "guid": "GD9Ocr5cDG",
       "type": "Emote",
       "name": "Look Around",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lookout_Scout#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/LookoutScout-1.png"
     },
@@ -2212,6 +2306,7 @@
       "guid": "RtxeObjJ-x",
       "type": "Emote",
       "name": "Look Around",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lookout_Scout#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/LookoutScout-1.png"
     },
@@ -2237,6 +2332,7 @@
       "guid": "vVUB_cGhZd",
       "type": "Emote",
       "name": "Telekinesis",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Levitating_Adept#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f2/LevitatingAdept-1.png",
       "order": 661
@@ -2245,6 +2341,7 @@
       "guid": "l6TWStE9Xr",
       "type": "Emote",
       "name": "Telekinesis",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Levitating_Adept#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f2/LevitatingAdept-1.png"
     },
@@ -2279,6 +2376,7 @@
       "guid": "9_H47RAVw-",
       "type": "Emote",
       "name": "Telekinesis",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Levitating_Adept#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f2/LevitatingAdept-1.png"
     },
@@ -2286,6 +2384,7 @@
       "guid": "yfJsC8H6F4",
       "type": "Emote",
       "name": "Telekinesis",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Levitating_Adept#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f2/LevitatingAdept-1.png"
     },
@@ -2309,6 +2408,7 @@
       "guid": "c1A0Bf98bJ",
       "type": "Emote",
       "name": "Float",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Meditating_Monastic#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Meditating-Monastic-1.png",
       "order": 671
@@ -2317,6 +2417,7 @@
       "guid": "hu9E5_AnJh",
       "type": "Emote",
       "name": "Float",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Meditating_Monastic#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Meditating-Monastic-1.png"
     },
@@ -2351,6 +2452,7 @@
       "guid": "of7E6FbO6S",
       "type": "Emote",
       "name": "Float",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Meditating_Monastic#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Meditating-Monastic-1.png"
     },
@@ -2358,6 +2460,7 @@
       "guid": "1icJGw6P2x",
       "type": "Emote",
       "name": "Float",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Meditating_Monastic#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Meditating-Monastic-1.png"
     },
@@ -2496,6 +2599,7 @@
       "guid": "EN-zwdMKW0",
       "type": "Emote",
       "name": "Pray",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Praying_Acolyte#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/PrayingAcolyte-1.png",
       "order": 681
@@ -2504,6 +2608,7 @@
       "guid": "3kiNK4eee-",
       "type": "Emote",
       "name": "Pray",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Praying_Acolyte#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/PrayingAcolyte-1.png"
     },
@@ -2538,6 +2643,7 @@
       "guid": "47u5kXt3wr",
       "type": "Emote",
       "name": "Pray",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Praying_Acolyte#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/PrayingAcolyte-1.png"
     },
@@ -2545,6 +2651,7 @@
       "guid": "ZHkYvZFLjE",
       "type": "Emote",
       "name": "Pray",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Praying_Acolyte#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/PrayingAcolyte-1.png"
     },
@@ -4039,6 +4146,7 @@
       "guid": "7L0kmOL8-h",
       "type": "Emote",
       "name": "Silent Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/SoAurora-Ultimate-Expression-Dance-1-Icon-Morybel-0146.png",
       "order": 961
@@ -4047,6 +4155,7 @@
       "guid": "iZ1lQxrYIi",
       "type": "Emote",
       "name": "Silent Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/SoAurora-Ultimate-Expression-Dance-1-Icon-Morybel-0146.png"
     },
@@ -4054,6 +4163,7 @@
       "guid": "3cRBKxvpUY",
       "type": "Emote",
       "name": "Silent Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/SoAurora-Ultimate-Expression-Dance-1-Icon-Morybel-0146.png"
     },
@@ -4067,6 +4177,7 @@
       "guid": "RNEBgyMjrV",
       "type": "Emote",
       "name": "Silent Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/SoAurora-Ultimate-Expression-Dance-1-Icon-Morybel-0146.png"
     },
@@ -4074,6 +4185,7 @@
       "guid": "uEYrMRIKMS",
       "type": "Emote",
       "name": "Conduct",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/SoAurora-Ultimate-Expression-Dance-2-Icon-Morybel-0146.png",
       "order": 951
@@ -4082,6 +4194,7 @@
       "guid": "VdWQyivAwr",
       "type": "Emote",
       "name": "Conduct",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/SoAurora-Ultimate-Expression-Dance-2-Icon-Morybel-0146.png"
     },
@@ -4089,6 +4202,7 @@
       "guid": "WaJAeLkow7",
       "type": "Emote",
       "name": "Conduct",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/SoAurora-Ultimate-Expression-Dance-2-Icon-Morybel-0146.png"
     },
@@ -4108,6 +4222,7 @@
       "guid": "KhbsMGJgui",
       "type": "Emote",
       "name": "Conduct",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/SoAurora-Ultimate-Expression-Dance-2-Icon-Morybel-0146.png"
     },
@@ -4115,6 +4230,7 @@
       "guid": "uSlZPzJdDo",
       "type": "Emote",
       "name": "Skipping",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/SoAurora-Ultimate-Expression-Dance-3-Icon-Morybel-0146.png",
       "order": 971
@@ -4123,6 +4239,7 @@
       "guid": "IJUeE1lOwt",
       "type": "Emote",
       "name": "Skipping",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/SoAurora-Ultimate-Expression-Dance-3-Icon-Morybel-0146.png"
     },
@@ -4130,6 +4247,7 @@
       "guid": "AR3AyfDRZu",
       "type": "Emote",
       "name": "Skipping",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/SoAurora-Ultimate-Expression-Dance-3-Icon-Morybel-0146.png"
     },
@@ -4150,6 +4268,7 @@
       "guid": "qKwEFLirdj",
       "type": "Emote",
       "name": "Skipping",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/SoAurora-Ultimate-Expression-Dance-3-Icon-Morybel-0146.png"
     },
@@ -4710,6 +4829,7 @@
       "guid": "bXiNLPtQyh",
       "type": "Emote",
       "name": "Yoga",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Guru#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/82/Mimi-4117_02_stretching_guru_emote.png",
       "order": 691
@@ -4718,6 +4838,7 @@
       "guid": "hFbdz8Wvye",
       "type": "Emote",
       "name": "Yoga",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Guru#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/82/Mimi-4117_02_stretching_guru_emote.png"
     },
@@ -4740,6 +4861,7 @@
       "guid": "j6B0Gx5Bra",
       "type": "Emote",
       "name": "Yoga",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Guru#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/82/Mimi-4117_02_stretching_guru_emote.png"
     },
@@ -4747,6 +4869,7 @@
       "guid": "JuLs_5VIyb",
       "type": "Emote",
       "name": "Yoga",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Guru#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/82/Mimi-4117_02_stretching_guru_emote.png"
     },
@@ -4782,6 +4905,7 @@
       "guid": "YnKXRCy5y9",
       "type": "Emote",
       "name": "Kabuki",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Provoking_Performer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Mimi-4117_02_provoking_performer_emote.png",
       "order": 341
@@ -4790,6 +4914,7 @@
       "guid": "LPnwWeKlf0",
       "type": "Emote",
       "name": "Kabuki",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Provoking_Performer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Mimi-4117_02_provoking_performer_emote.png"
     },
@@ -4810,6 +4935,7 @@
       "guid": "oTQGUs9w8K",
       "type": "Emote",
       "name": "Kabuki",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Provoking_Performer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Mimi-4117_02_provoking_performer_emote.png"
     },
@@ -4817,6 +4943,7 @@
       "guid": "znqKbunN1C",
       "type": "Emote",
       "name": "Kabuki",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Provoking_Performer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Mimi-4117_02_provoking_performer_emote.png"
     },
@@ -4861,6 +4988,7 @@
       "guid": "2EjYbZlJwr",
       "type": "Emote",
       "name": "Leap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Leaping_Dancer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/67/Mimi-4117_02_leaping_dancer_emote.png",
       "order": 441
@@ -4869,6 +4997,7 @@
       "guid": "Q5LhJRWFiF",
       "type": "Emote",
       "name": "Leap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Leaping_Dancer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/67/Mimi-4117_02_leaping_dancer_emote.png"
     },
@@ -4891,6 +5020,7 @@
       "guid": "QVo-MuF4gw",
       "type": "Emote",
       "name": "Leap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Leaping_Dancer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/67/Mimi-4117_02_leaping_dancer_emote.png"
     },
@@ -4898,6 +5028,7 @@
       "guid": "Q4z_OukNlE",
       "type": "Emote",
       "name": "Leap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Leaping_Dancer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/67/Mimi-4117_02_leaping_dancer_emote.png"
     },
@@ -4933,6 +5064,7 @@
       "guid": "zRlUm_oL2p",
       "type": "Emote",
       "name": "Acknowledge",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Protector#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Mimi-4117_02_saluting_protector_emote.png",
       "order": 591
@@ -4941,6 +5073,7 @@
       "guid": "tUzGovgVRK",
       "type": "Emote",
       "name": "Acknowledge",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Protector#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Mimi-4117_02_saluting_protector_emote.png"
     },
@@ -4961,6 +5094,7 @@
       "guid": "dor3unMei7",
       "type": "Emote",
       "name": "Acknowledge",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Protector#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Mimi-4117_02_saluting_protector_emote.png"
     },
@@ -4968,6 +5102,7 @@
       "guid": "K82EgKZAwe",
       "type": "Emote",
       "name": "Acknowledge",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Protector#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Mimi-4117_02_saluting_protector_emote.png"
     },
@@ -5012,6 +5147,7 @@
       "guid": "NpbuKXMxKS",
       "type": "Emote",
       "name": "Kung Fu",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Greeting_Shaman#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9a/Mimi-4117_02_greeting_shaman_emote.png",
       "order": 601
@@ -5020,6 +5156,7 @@
       "guid": "5QWjZVAA-9",
       "type": "Emote",
       "name": "Kung Fu",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Greeting_Shaman#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9a/Mimi-4117_02_greeting_shaman_emote.png"
     },
@@ -5042,6 +5179,7 @@
       "guid": "j3BNKt3Qmi",
       "type": "Emote",
       "name": "Kung Fu",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Greeting_Shaman#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9a/Mimi-4117_02_greeting_shaman_emote.png"
     },
@@ -5049,6 +5187,7 @@
       "guid": "7MpXlundFS",
       "type": "Emote",
       "name": "Kung Fu",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Greeting_Shaman#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9a/Mimi-4117_02_greeting_shaman_emote.png"
     },
@@ -5086,6 +5225,7 @@
       "guid": "G9wVSFG6I_",
       "type": "Emote",
       "name": "Piggyback",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Piggyback_Lightseeker#Friend_Action" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/Mimi-4117_03_piggyback_lightseeker_emote.png"
     },
@@ -5114,6 +5254,7 @@
       "guid": "HtVnkK980q",
       "type": "Emote",
       "name": "Piggyback",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Piggyback_Lightseeker#Friend_Action" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/Mimi-4117_03_piggyback_lightseeker_emote.png"
     },
@@ -5152,6 +5293,7 @@
       "guid": "9sYCtuZch3",
       "type": "Emote",
       "name": "Double-Five",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Doublefive_Light_Catcher#Friend_Action" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/Mimi-4117_03_doublefive_light_catcher_emote.png"
     },
@@ -5183,6 +5325,7 @@
       "guid": "nfeBnolyEY",
       "type": "Emote",
       "name": "Double-Five",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Doublefive_Light_Catcher#Friend_Action" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/Mimi-4117_03_doublefive_light_catcher_emote.png"
     },
@@ -5296,6 +5439,7 @@
       "guid": "tmhe-C2cN3",
       "type": "Emote",
       "name": "Triple Axel",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Twirling_Champion#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/Mimi-4117_03_twirling_champion_emote.png",
       "order": 451
@@ -5304,6 +5448,7 @@
       "guid": "zjAeiE3x_t",
       "type": "Emote",
       "name": "Triple Axel",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Twirling_Champion#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/Mimi-4117_03_twirling_champion_emote.png"
     },
@@ -5326,6 +5471,7 @@
       "guid": "zhwG9yJ2mi",
       "type": "Emote",
       "name": "Triple Axel",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Twirling_Champion#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/Mimi-4117_03_twirling_champion_emote.png"
     },
@@ -5333,6 +5479,7 @@
       "guid": "touhpuoYRG",
       "type": "Emote",
       "name": "Triple Axel",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Twirling_Champion#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/Mimi-4117_03_twirling_champion_emote.png"
     },
@@ -5464,6 +5611,7 @@
       "guid": "Bnrptwn3vv",
       "type": "Emote",
       "name": "Shush",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shushing_Light_Scholar#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Mimi-4117_03_shushing_light_scholar_emote.png",
       "order": 701
@@ -5472,6 +5620,7 @@
       "guid": "TqyXKGohBg",
       "type": "Emote",
       "name": "Shush",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shushing_Light_Scholar#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Mimi-4117_03_shushing_light_scholar_emote.png"
     },
@@ -5494,6 +5643,7 @@
       "guid": "kYxJuHr1mX",
       "type": "Emote",
       "name": "Shush",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shushing_Light_Scholar#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Mimi-4117_03_shushing_light_scholar_emote.png"
     },
@@ -5501,6 +5651,7 @@
       "guid": "MtnosL0i54",
       "type": "Emote",
       "name": "Shush",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shushing_Light_Scholar#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Mimi-4117_03_shushing_light_scholar_emote.png"
     },
@@ -5538,6 +5689,7 @@
       "guid": "EdkgJhVl7F",
       "type": "Emote",
       "name": "Confetti",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confetti_Cousin#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Belonging_confetti.png",
       "order": 461
@@ -5546,6 +5698,7 @@
       "guid": "_KkFXT0brp",
       "type": "Emote",
       "name": "Confetti",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confetti_Cousin#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Belonging_confetti.png"
     },
@@ -5565,6 +5718,7 @@
       "guid": "0nUupQHHcx",
       "type": "Emote",
       "name": "Confetti",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confetti_Cousin#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Belonging_confetti.png"
     },
@@ -5572,6 +5726,7 @@
       "guid": "u2qrLrrl7v",
       "type": "Emote",
       "name": "Confetti",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confetti_Cousin#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Belonging_confetti.png"
     },
@@ -5622,6 +5777,7 @@
       "guid": "o46E_Adz2z",
       "type": "Emote",
       "name": "Boogie Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Boogie_Kid#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Belonging_dancing.png",
       "order": 471
@@ -5630,6 +5786,7 @@
       "guid": "jn9V5Dc56I",
       "type": "Emote",
       "name": "Boogie Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Boogie_Kid#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Belonging_dancing.png"
     },
@@ -5649,6 +5806,7 @@
       "guid": "AnOX8p-Z5f",
       "type": "Emote",
       "name": "Boogie Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Boogie_Kid#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Belonging_dancing.png"
     },
@@ -5656,6 +5814,7 @@
       "guid": "ThC1rC0jC4",
       "type": "Emote",
       "name": "Boogie Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Boogie_Kid#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Belonging_dancing.png"
     },
@@ -5706,6 +5865,7 @@
       "guid": "eEwMzjwfoS",
       "type": "Emote",
       "name": "Sparkler",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sparkler_Parent#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/Belonging_sparkler.png",
       "order": 711
@@ -5714,6 +5874,7 @@
       "guid": "sSgceH7emy",
       "type": "Emote",
       "name": "Sparkler",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sparkler_Parent#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/Belonging_sparkler.png"
     },
@@ -5736,6 +5897,7 @@
       "guid": "l663HjIDEd",
       "type": "Emote",
       "name": "Sparkler",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sparkler_Parent#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/Belonging_sparkler.png"
     },
@@ -5743,6 +5905,7 @@
       "guid": "X81UhfMlB2",
       "type": "Emote",
       "name": "Sparkler",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sparkler_Parent#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/Belonging_sparkler.png"
     },
@@ -5889,6 +6052,7 @@
       "guid": "CtEU0Osb2E",
       "type": "Emote",
       "name": "Don't Go!",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleaful_Parent#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/Belonging_crawl.png",
       "order": 611
@@ -5897,6 +6061,7 @@
       "guid": "oqndH_vtJJ",
       "type": "Emote",
       "name": "Don't Go!",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleaful_Parent#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/Belonging_crawl.png"
     },
@@ -5919,6 +6084,7 @@
       "guid": "sTSrAZzgqU",
       "type": "Emote",
       "name": "Don't Go!",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleaful_Parent#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/Belonging_crawl.png"
     },
@@ -5926,6 +6092,7 @@
       "guid": "D5hLl-_xZd",
       "type": "Emote",
       "name": "Don't Go!",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleaful_Parent#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/Belonging_crawl.png"
     },
@@ -5976,6 +6143,7 @@
       "guid": "YUAzM6p_2j",
       "type": "Emote",
       "name": "Hair Tousle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hairtousle_Teen#Friend_Action" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/Hair_tousle.png"
     },
@@ -6002,6 +6170,7 @@
       "guid": "0f9auBppfc",
       "type": "Emote",
       "name": "Hair Tousle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hairtousle_Teen#Friend_Action" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/Hair_tousle.png"
     },
@@ -6060,6 +6229,7 @@
       "guid": "T9ZZMbXM0p",
       "type": "Emote",
       "name": "Welcome",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Greeter#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Emote-curtsy.png",
       "order": 131
@@ -6068,6 +6238,7 @@
       "guid": "Lpi2B9yp7E",
       "type": "Emote",
       "name": "Welcome",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Greeter#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Emote-curtsy.png"
     },
@@ -6088,6 +6259,7 @@
       "guid": "8p1dB9WsP1",
       "type": "Emote",
       "name": "Welcome",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Greeter#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Emote-curtsy.png"
     },
@@ -6095,6 +6267,7 @@
       "guid": "T835b5bBNS",
       "type": "Emote",
       "name": "Welcome",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Greeter#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Emote-curtsy.png"
     },
@@ -6152,6 +6325,7 @@
       "guid": "72q94N8VCj",
       "type": "Emote",
       "name": "Spin Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Festival_Spin_Dancer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/Emote-dance.png",
       "order": 481
@@ -6160,6 +6334,7 @@
       "guid": "Uszoh-ONkR",
       "type": "Emote",
       "name": "Spin Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Festival_Spin_Dancer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/Emote-dance.png"
     },
@@ -6180,6 +6355,7 @@
       "guid": "ZaNb7p2iqw",
       "type": "Emote",
       "name": "Spin Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Festival_Spin_Dancer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/Emote-dance.png"
     },
@@ -6187,6 +6363,7 @@
       "guid": "9v5mmfY2I4",
       "type": "Emote",
       "name": "Spin Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Festival_Spin_Dancer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/Emote-dance.png"
     },
@@ -6253,6 +6430,7 @@
       "guid": "mYHK8KGcDb",
       "type": "Emote",
       "name": "Blow Kiss",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Admiring_Actor#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6d/Emote-blow_kisses.png",
       "order": 231
@@ -6261,6 +6439,7 @@
       "guid": "DQhS5AkEKu",
       "type": "Emote",
       "name": "Blow Kiss",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Admiring_Actor#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6d/Emote-blow_kisses.png"
     },
@@ -6281,6 +6460,7 @@
       "guid": "R62rXvPti6",
       "type": "Emote",
       "name": "Blow Kiss",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Admiring_Actor#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6d/Emote-blow_kisses.png"
     },
@@ -6288,6 +6468,7 @@
       "guid": "X1oM2uVzop",
       "type": "Emote",
       "name": "Blow Kiss",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Admiring_Actor#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6d/Emote-blow_kisses.png"
     },
@@ -6338,6 +6519,7 @@
       "guid": "bcJTF4AAEe",
       "type": "Emote",
       "name": "Juggle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Juggler#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Emote-juggle.png",
       "order": 491
@@ -6346,6 +6528,7 @@
       "guid": "rt7_sCQiHh",
       "type": "Emote",
       "name": "Juggle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Juggler#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Emote-juggle.png"
     },
@@ -6368,6 +6551,7 @@
       "guid": "S9zHdixzVO",
       "type": "Emote",
       "name": "Juggle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Juggler#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Emote-juggle.png"
     },
@@ -6375,6 +6559,7 @@
       "guid": "HlohlGb5MA",
       "type": "Emote",
       "name": "Juggle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Juggler#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Emote-juggle.png"
     },
@@ -6440,6 +6625,7 @@
       "guid": "g3peZ7bo5z",
       "type": "Emote",
       "name": "Respect",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Respectful_Pianist#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Emote-respect.png",
       "order": 561
@@ -6448,6 +6634,7 @@
       "guid": "4hiIWJy7qv",
       "type": "Emote",
       "name": "Respect",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Respectful_Pianist#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Emote-respect.png"
     },
@@ -6470,6 +6657,7 @@
       "guid": "DYLsc2p_1T",
       "type": "Emote",
       "name": "Respect",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Respectful_Pianist#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Emote-respect.png"
     },
@@ -6477,6 +6665,7 @@
       "guid": "khMbyOBwco",
       "type": "Emote",
       "name": "Respect",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Respectful_Pianist#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Emote-respect.png"
     },
@@ -6533,6 +6722,7 @@
       "guid": "qwrbhllE1N",
       "type": "Emote",
       "name": "Thinking",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Thoughtful_Director#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Emote-thinking.png",
       "order": 721
@@ -6541,6 +6731,7 @@
       "guid": "zPUl7UL87P",
       "type": "Emote",
       "name": "Thinking",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Thoughtful_Director#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Emote-thinking.png"
     },
@@ -6563,6 +6754,7 @@
       "guid": "cSzED5jEt_",
       "type": "Emote",
       "name": "Thinking",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Thoughtful_Director#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Emote-thinking.png"
     },
@@ -6570,6 +6762,7 @@
       "guid": "SLjFXYFsjW",
       "type": "Emote",
       "name": "Thinking",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Thoughtful_Director#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Emote-thinking.png"
     },
@@ -6628,6 +6821,7 @@
       "guid": "WhcCC138s8",
       "type": "Emote",
       "name": "Nod",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nodding_Muralist#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Head_nod_white_on_black.png",
       "order": 141
@@ -6636,6 +6830,7 @@
       "guid": "D72h3-WjJD",
       "type": "Emote",
       "name": "Nod",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nodding_Muralist#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Head_nod_white_on_black.png"
     },
@@ -6658,6 +6853,7 @@
       "guid": "rYq-RTnkiN",
       "type": "Emote",
       "name": "Nod",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nodding_Muralist#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Head_nod_white_on_black.png"
     },
@@ -6665,6 +6861,7 @@
       "guid": "sbkNjwrgIc",
       "type": "Emote",
       "name": "Nod",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nodding_Muralist#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Head_nod_white_on_black.png"
     },
@@ -6706,6 +6903,7 @@
       "guid": "gFaU0Zm95W",
       "type": "Emote",
       "name": "Shrug",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Indifferent_Alchemist#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Shrug_white_on_black.png",
       "order": 351
@@ -6714,6 +6912,7 @@
       "guid": "5bwnWkR0DG",
       "type": "Emote",
       "name": "Shrug",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Indifferent_Alchemist#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Shrug_white_on_black.png"
     },
@@ -6736,6 +6935,7 @@
       "guid": "8qHEcZWhOt",
       "type": "Emote",
       "name": "Shrug",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Indifferent_Alchemist#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Shrug_white_on_black.png"
     },
@@ -6743,6 +6943,7 @@
       "guid": "HD8j6J2ysy",
       "type": "Emote",
       "name": "Shrug",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Indifferent_Alchemist#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Shrug_white_on_black.png"
     },
@@ -6799,6 +7000,7 @@
       "guid": "4cZR63EJEP",
       "type": "Emote",
       "name": "Crab Walk",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Walker#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/Crab_walk_white_on_black.png",
       "order": 501
@@ -6807,6 +7009,7 @@
       "guid": "PcsXYI_YLj",
       "type": "Emote",
       "name": "Crab Walk",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Walker#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/Crab_walk_white_on_black.png"
     },
@@ -6829,6 +7032,7 @@
       "guid": "lw-A9eS1gx",
       "type": "Emote",
       "name": "Crab Walk",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Walker#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/Crab_walk_white_on_black.png"
     },
@@ -6836,6 +7040,7 @@
       "guid": "48_BopWKQ5",
       "type": "Emote",
       "name": "Crab Walk",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Walker#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/Crab_walk_white_on_black.png"
     },
@@ -6877,6 +7082,7 @@
       "guid": "3difltLJOc",
       "type": "Emote",
       "name": "Boo",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scarecrow_Farmer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Boo_white_on_black.png",
       "order": 621
@@ -6885,6 +7091,7 @@
       "guid": "DGC8JcQK5y",
       "type": "Emote",
       "name": "Boo",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scarecrow_Farmer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Boo_white_on_black.png"
     },
@@ -6907,6 +7114,7 @@
       "guid": "ixFFdCm9cG",
       "type": "Emote",
       "name": "Boo",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scarecrow_Farmer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Boo_white_on_black.png"
     },
@@ -6914,6 +7122,7 @@
       "guid": "sNJx3GgOLF",
       "type": "Emote",
       "name": "Boo",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scarecrow_Farmer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Boo_white_on_black.png"
     },
@@ -6955,6 +7164,7 @@
       "guid": "RzstnkbQ8d",
       "type": "Emote",
       "name": "Doze",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Snoozing_Carpenter#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/Fall_asleep_white_on_black.png",
       "order": 731
@@ -6963,6 +7173,7 @@
       "guid": "o9Wt1MLcrz",
       "type": "Emote",
       "name": "Doze",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Snoozing_Carpenter#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/Fall_asleep_white_on_black.png"
     },
@@ -6985,6 +7196,7 @@
       "guid": "xfv-AbRiCY",
       "type": "Emote",
       "name": "Doze",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Snoozing_Carpenter#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/Fall_asleep_white_on_black.png"
     },
@@ -6992,6 +7204,7 @@
       "guid": "IL31Z--01u",
       "type": "Emote",
       "name": "Doze",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Snoozing_Carpenter#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/Fall_asleep_white_on_black.png"
     },
@@ -7033,6 +7246,7 @@
       "guid": "aBFJssIm0e",
       "type": "Emote",
       "name": "Play Fight",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Friend_Action" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b9/Play_fight_lvl_2_white_on_black.png"
     },
@@ -7067,6 +7281,7 @@
       "guid": "PkKzcwatL6",
       "type": "Emote",
       "name": "Play Fight",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Friend_Action" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b9/Play_fight_lvl_2_white_on_black.png"
     },
@@ -7282,6 +7497,7 @@
       "guid": "fgYKKXiPMf",
       "type": "Emote",
       "name": "Rally Cheer",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rallying_Thrillseeker#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/SOS_rally.png",
       "order": 511
@@ -7290,6 +7506,7 @@
       "guid": "Q3SUBd3Vbl",
       "type": "Emote",
       "name": "Rally Cheer",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rallying_Thrillseeker#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/SOS_rally.png"
     },
@@ -7312,6 +7529,7 @@
       "guid": "buDIh3u4OX",
       "type": "Emote",
       "name": "Rally Cheer",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rallying_Thrillseeker#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/SOS_rally.png"
     },
@@ -7319,6 +7537,7 @@
       "guid": "bPWMijGpDI",
       "type": "Emote",
       "name": "Rally Cheer",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rallying_Thrillseeker#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/SOS_rally.png"
     },
@@ -7360,6 +7579,7 @@
       "guid": "_-Am5v5QWs",
       "type": "Emote",
       "name": "Grumpy",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/SoS_grouch.png",
       "order": 361
@@ -7368,6 +7588,7 @@
       "guid": "91x-6KiNlb",
       "type": "Emote",
       "name": "Grumpy",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/SoS_grouch.png"
     },
@@ -7390,6 +7611,7 @@
       "guid": "AjOxFBIEsi",
       "type": "Emote",
       "name": "Grumpy",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/SoS_grouch.png"
     },
@@ -7397,6 +7619,7 @@
       "guid": "F9ZODZ6Qs8",
       "type": "Emote",
       "name": "Grumpy",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/SoS_grouch.png"
     },
@@ -7453,6 +7676,7 @@
       "guid": "dpF382RUvu",
       "type": "Emote",
       "name": "Grateful",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Grateful_Shell_Collector#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/SOS_grateful.png",
       "order": 241
@@ -7461,6 +7685,7 @@
       "guid": "IDDSw982ER",
       "type": "Emote",
       "name": "Grateful",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Grateful_Shell_Collector#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/SOS_grateful.png"
     },
@@ -7483,6 +7708,7 @@
       "guid": "xl7jZqLFwD",
       "type": "Emote",
       "name": "Grateful",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Grateful_Shell_Collector#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/SOS_grateful.png"
     },
@@ -7490,6 +7716,7 @@
       "guid": "B66Wbe_vYk",
       "type": "Emote",
       "name": "Grateful",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Grateful_Shell_Collector#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/SOS_grateful.png"
     },
@@ -7540,6 +7767,7 @@
       "guid": "QNd_KFZo7Y",
       "type": "Emote",
       "name": "Belly Scratch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chill_Sunbather#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/SOS_Chill.png",
       "order": 251
@@ -7548,6 +7776,7 @@
       "guid": "LZqy5g4Xpa",
       "type": "Emote",
       "name": "Belly Scratch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chill_Sunbather#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/SOS_Chill.png"
     },
@@ -7570,6 +7799,7 @@
       "guid": "phajnn85-p",
       "type": "Emote",
       "name": "Belly Scratch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chill_Sunbather#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/SOS_Chill.png"
     },
@@ -7577,6 +7807,7 @@
       "guid": "2LKc2kVIga",
       "type": "Emote",
       "name": "Belly Scratch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chill_Sunbather#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/SOS_Chill.png"
     },
@@ -7644,6 +7875,7 @@
       "guid": "GkHHcjKlV-",
       "type": "Emote",
       "name": "Deep Breath",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Water#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/SoP_deep_breath.png",
       "order": 751
@@ -7652,6 +7884,7 @@
       "guid": "a1mWcW4Pll",
       "type": "Emote",
       "name": "Deep Breath",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Water#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/SoP_deep_breath.png"
     },
@@ -7674,6 +7907,7 @@
       "guid": "3H28hhg2kF",
       "type": "Emote",
       "name": "Deep Breath",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Water#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/SoP_deep_breath.png"
     },
@@ -7681,6 +7915,7 @@
       "guid": "DyDCYzuiZU",
       "type": "Emote",
       "name": "Deep Breath",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Water#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/SoP_deep_breath.png"
     },
@@ -7746,6 +7981,7 @@
       "guid": "N3W56zu42m",
       "type": "Emote",
       "name": "Dust Off",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Earth#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/SoP_dust_off.png",
       "order": 631
@@ -7754,6 +7990,7 @@
       "guid": "VWQdrhMcwH",
       "type": "Emote",
       "name": "Dust Off",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Earth#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/SoP_dust_off.png"
     },
@@ -7776,6 +8013,7 @@
       "guid": "EIVC6EkYVC",
       "type": "Emote",
       "name": "Dust Off",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Earth#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/SoP_dust_off.png"
     },
@@ -7783,6 +8021,7 @@
       "guid": "WNpYia1GaL",
       "type": "Emote",
       "name": "Dust Off",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Earth#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/SoP_dust_off.png"
     },
@@ -7855,6 +8094,7 @@
       "guid": "p07giC7q6F",
       "type": "Emote",
       "name": "Balance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Air#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/SoP_balance.png",
       "order": 741
@@ -7863,6 +8103,7 @@
       "guid": "1COJ0_lu9H",
       "type": "Emote",
       "name": "Balance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Air#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/SoP_balance.png"
     },
@@ -7885,6 +8126,7 @@
       "guid": "vmZnZiDaRp",
       "type": "Emote",
       "name": "Balance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Air#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/SoP_balance.png"
     },
@@ -7892,6 +8134,7 @@
       "guid": "sS5uFB29XN",
       "type": "Emote",
       "name": "Balance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Air#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/SoP_balance.png"
     },
@@ -7957,6 +8200,7 @@
       "guid": "-9bN5PmMbs",
       "type": "Emote",
       "name": "Chest Pound",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/SoP_chest_pound.png",
       "order": 641
@@ -7965,6 +8209,7 @@
       "guid": "lv8aUui_2g",
       "type": "Emote",
       "name": "Chest Pound",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/SoP_chest_pound.png"
     },
@@ -7987,6 +8232,7 @@
       "guid": "oWEC_F0xLY",
       "type": "Emote",
       "name": "Chest Pound",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/SoP_chest_pound.png"
     },
@@ -7994,6 +8240,7 @@
       "guid": "ofbkhI0JKU",
       "type": "Emote",
       "name": "Chest Pound",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/SoP_chest_pound.png"
     },
@@ -8071,6 +8318,7 @@
       "guid": "sw2YxczeGz",
       "type": "Emote",
       "name": "Bearhug",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bearhug_Hermit#Friend_Action" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9e/Season_of_Dreams_-_Bearhug_hermit.png"
     },
@@ -8112,6 +8360,7 @@
       "guid": "YzY-N81J1l",
       "type": "Emote",
       "name": "Bearhug",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bearhug_Hermit#Friend_Action" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9e/Season_of_Dreams_-_Bearhug_hermit.png"
     },
@@ -8156,6 +8405,7 @@
       "guid": "mK02s3A4Sy",
       "type": "Emote",
       "name": "Show Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dancing_Performer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Season_of_Dreams_-_Dancing_performer.png",
       "order": 531
@@ -8164,6 +8414,7 @@
       "guid": "VR8uQXAzzZ",
       "type": "Emote",
       "name": "Show Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dancing_Performer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Season_of_Dreams_-_Dancing_performer.png"
     },
@@ -8186,6 +8437,7 @@
       "guid": "IWzRV-xeez",
       "type": "Emote",
       "name": "Show Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dancing_Performer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Season_of_Dreams_-_Dancing_performer.png"
     },
@@ -8193,6 +8445,7 @@
       "guid": "kabDjVwtC9",
       "type": "Emote",
       "name": "Show Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dancing_Performer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Season_of_Dreams_-_Dancing_performer.png"
     },
@@ -8240,6 +8493,7 @@
       "guid": "hV3bFwgh_u",
       "type": "Emote",
       "name": "Peek",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Peeking_Postman#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Season_of_Dreams_-_Peeking_postman.png",
       "order": 371
@@ -8248,6 +8502,7 @@
       "guid": "iNGMlJTDL0",
       "type": "Emote",
       "name": "Peek",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Peeking_Postman#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Season_of_Dreams_-_Peeking_postman.png"
     },
@@ -8268,6 +8523,7 @@
       "guid": "ehhr3uxVaH",
       "type": "Emote",
       "name": "Peek",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Peeking_Postman#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Season_of_Dreams_-_Peeking_postman.png"
     },
@@ -8275,6 +8531,7 @@
       "guid": "0S9JrVZK6v",
       "type": "Emote",
       "name": "Peek",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Peeking_Postman#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Season_of_Dreams_-_Peeking_postman.png"
     },
@@ -8334,6 +8591,7 @@
       "guid": "NOJ5yfbV_j",
       "type": "Emote",
       "name": "Spin Trick",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Spinning_Mentor#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Season_of_Dreams_-_Spinning_mentor.png",
       "order": 521
@@ -8342,6 +8600,7 @@
       "guid": "tp172HbBKC",
       "type": "Emote",
       "name": "Spin Trick",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Spinning_Mentor#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Season_of_Dreams_-_Spinning_mentor.png"
     },
@@ -8364,6 +8623,7 @@
       "guid": "CCeCnDEyRM",
       "type": "Emote",
       "name": "Spin Trick",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Spinning_Mentor#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Season_of_Dreams_-_Spinning_mentor.png"
     },
@@ -8371,6 +8631,7 @@
       "guid": "SUGO6FwRX8",
       "type": "Emote",
       "name": "Spin Trick",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Spinning_Mentor#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Season_of_Dreams_-_Spinning_mentor.png"
     },
@@ -8429,6 +8690,7 @@
       "guid": "PKx3NYE71T",
       "type": "Emote",
       "name": "Facepalm",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Baffled_Botanist#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Assembly-Facepalm-emote.png",
       "order": 391
@@ -8437,6 +8699,7 @@
       "guid": "rsYXcsOjgR",
       "type": "Emote",
       "name": "Facepalm",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Baffled_Botanist#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Assembly-Facepalm-emote.png"
     },
@@ -8459,6 +8722,7 @@
       "guid": "turlkU87QA",
       "type": "Emote",
       "name": "Facepalm",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Baffled_Botanist#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Assembly-Facepalm-emote.png"
     },
@@ -8466,6 +8730,7 @@
       "guid": "yqN3H8SyIs",
       "type": "Emote",
       "name": "Facepalm",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Baffled_Botanist#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Assembly-Facepalm-emote.png"
     },
@@ -8522,6 +8787,7 @@
       "guid": "GDEPmZva_3",
       "type": "Emote",
       "name": "Scold",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scolding_Student#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Assembly-scolding-emote.png",
       "order": 151
@@ -8530,6 +8796,7 @@
       "guid": "sEIwClFXji",
       "type": "Emote",
       "name": "Scold",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scolding_Student#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Assembly-scolding-emote.png"
     },
@@ -8552,6 +8819,7 @@
       "guid": "Y0xKlLOykh",
       "type": "Emote",
       "name": "Scold",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scolding_Student#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Assembly-scolding-emote.png"
     },
@@ -8559,6 +8827,7 @@
       "guid": "YDHt4GuNvK",
       "type": "Emote",
       "name": "Scold",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scolding_Student#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Assembly-scolding-emote.png"
     },
@@ -8615,6 +8884,7 @@
       "guid": "KyJwYhzGVj",
       "type": "Emote",
       "name": "Eww",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scaredy_Cadet#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/Assembly-Scaredy-emote.png",
       "order": 381
@@ -8623,6 +8893,7 @@
       "guid": "owZSOBEp_z",
       "type": "Emote",
       "name": "Eww",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scaredy_Cadet#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/Assembly-Scaredy-emote.png"
     },
@@ -8645,6 +8916,7 @@
       "guid": "UUOmL9cnbz",
       "type": "Emote",
       "name": "Eww",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scaredy_Cadet#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/Assembly-Scaredy-emote.png"
     },
@@ -8652,6 +8924,7 @@
       "guid": "3HxtK5BEns",
       "type": "Emote",
       "name": "Eww",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scaredy_Cadet#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/Assembly-Scaredy-emote.png"
     },
@@ -8709,6 +8982,7 @@
       "guid": "dNoANrAQV0",
       "type": "Emote",
       "name": "Marching",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Marching_Adventurer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Assembly-march-emote.png",
       "order": 651
@@ -8717,6 +8991,7 @@
       "guid": "0xqk-p9fsY",
       "type": "Emote",
       "name": "Marching",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Marching_Adventurer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Assembly-march-emote.png"
     },
@@ -8739,6 +9014,7 @@
       "guid": "owG_KD9opY",
       "type": "Emote",
       "name": "Marching",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Marching_Adventurer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Assembly-march-emote.png"
     },
@@ -8746,6 +9022,7 @@
       "guid": "dLKdIkOcZ0",
       "type": "Emote",
       "name": "Marching",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Marching_Adventurer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Assembly-march-emote.png"
     },
@@ -8802,6 +9079,7 @@
       "guid": "iSTnFoyozE",
       "type": "Emote",
       "name": "Chuckle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/Assembly-chuckling-emote.png",
       "order": 261
@@ -8810,6 +9088,7 @@
       "guid": "ymKZH8BJwt",
       "type": "Emote",
       "name": "Chuckle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/Assembly-chuckling-emote.png"
     },
@@ -8832,6 +9111,7 @@
       "guid": "HPP2RAku32",
       "type": "Emote",
       "name": "Chuckle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/Assembly-chuckling-emote.png"
     },
@@ -8839,6 +9119,7 @@
       "guid": "81N0_-C6mq",
       "type": "Emote",
       "name": "Chuckle",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/Assembly-chuckling-emote.png"
     },
@@ -8904,6 +9185,7 @@
       "guid": "AuugJTG-Nl",
       "type": "Emote",
       "name": "Bubbles",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Daydream_Forester#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Assembly-Daydream-emote.png",
       "order": 761
@@ -8912,6 +9194,7 @@
       "guid": "nT-zyxTRzs",
       "type": "Emote",
       "name": "Bubbles",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Daydream_Forester#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Assembly-Daydream-emote.png"
     },
@@ -8934,6 +9217,7 @@
       "guid": "LBmnlOT0UP",
       "type": "Emote",
       "name": "Bubbles",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Daydream_Forester#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Assembly-Daydream-emote.png"
     },
@@ -8941,6 +9225,7 @@
       "guid": "Ujm1hPDpWr",
       "type": "Emote",
       "name": "Bubbles",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Daydream_Forester#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Assembly-Daydream-emote.png"
     },
@@ -8997,6 +9282,7 @@
       "guid": "1YJ13EOwIQ",
       "type": "Emote",
       "name": "Beckon",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Beckoning_Ruler#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/SOTLP-Beckoning-Ruler.png",
       "order": 771
@@ -9005,6 +9291,7 @@
       "guid": "_ws5QlV4Tp",
       "type": "Emote",
       "name": "Beckon",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Beckoning_Ruler#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/SOTLP-Beckoning-Ruler.png"
     },
@@ -9027,6 +9314,7 @@
       "guid": "W4i9e6Vt6d",
       "type": "Emote",
       "name": "Beckon",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Beckoning_Ruler#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/SOTLP-Beckoning-Ruler.png"
     },
@@ -9034,6 +9322,7 @@
       "guid": "-4aZ5Mq9aw",
       "type": "Emote",
       "name": "Beckon",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Beckoning_Ruler#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/SOTLP-Beckoning-Ruler.png"
     },
@@ -9076,6 +9365,7 @@
       "guid": "qcsiXdqfGT",
       "type": "Emote",
       "name": "Gloat",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Gloating_Narcissist#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/SOTLP-Gloating-Narcissist.png",
       "order": 781
@@ -9084,6 +9374,7 @@
       "guid": "SNhn8BVb7a",
       "type": "Emote",
       "name": "Gloat",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Gloating_Narcissist#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/SOTLP-Gloating-Narcissist.png"
     },
@@ -9104,6 +9395,7 @@
       "guid": "XhRW44vwiq",
       "type": "Emote",
       "name": "Gloat",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Gloating_Narcissist#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/SOTLP-Gloating-Narcissist.png"
     },
@@ -9111,6 +9403,7 @@
       "guid": "g-tnZqaKbi",
       "type": "Emote",
       "name": "Gloat",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Gloating_Narcissist#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/SOTLP-Gloating-Narcissist.png"
     },
@@ -9168,6 +9461,7 @@
       "guid": "UhtkKIM3ol",
       "type": "Emote",
       "name": "Stretch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Lamplighter#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/SOTLP-Stretching-Lamplighter.png",
       "order": 791
@@ -9176,6 +9470,7 @@
       "guid": "NwYn4D2Gag",
       "type": "Emote",
       "name": "Stretch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Lamplighter#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/SOTLP-Stretching-Lamplighter.png"
     },
@@ -9198,6 +9493,7 @@
       "guid": "0f_f0iJMqN",
       "type": "Emote",
       "name": "Stretch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Lamplighter#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/SOTLP-Stretching-Lamplighter.png"
     },
@@ -9205,6 +9501,7 @@
       "guid": "e-yLNwofBb",
       "type": "Emote",
       "name": "Stretch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Lamplighter#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/SOTLP-Stretching-Lamplighter.png"
     },
@@ -9235,6 +9532,7 @@
       "guid": "5J5FDssiU9",
       "type": "Emote",
       "name": "Slouch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slouching_Soldier#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/SOTLP-Slouching-Soldier.png",
       "order": 801
@@ -9243,6 +9541,7 @@
       "guid": "Gx5YAc7jLr",
       "type": "Emote",
       "name": "Slouch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slouching_Soldier#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/SOTLP-Slouching-Soldier.png"
     },
@@ -9265,6 +9564,7 @@
       "guid": "ZZ21lI_L9o",
       "type": "Emote",
       "name": "Slouch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slouching_Soldier#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/SOTLP-Slouching-Soldier.png"
     },
@@ -9272,6 +9572,7 @@
       "guid": "OpLAmdRCNM",
       "type": "Emote",
       "name": "Slouch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slouching_Soldier#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/SOTLP-Slouching-Soldier.png"
     },
@@ -9327,6 +9628,7 @@
       "guid": "zgI2lfTGvf",
       "type": "Emote",
       "name": "Sneeze",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sneezing_Geographer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/SOTLP-Sneezing-Geographer.png",
       "order": 811
@@ -9335,6 +9637,7 @@
       "guid": "muRzuaFzwA",
       "type": "Emote",
       "name": "Sneeze",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sneezing_Geographer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/SOTLP-Sneezing-Geographer.png"
     },
@@ -9357,6 +9660,7 @@
       "guid": "cYQ6gsue9A",
       "type": "Emote",
       "name": "Sneeze",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sneezing_Geographer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/SOTLP-Sneezing-Geographer.png"
     },
@@ -9364,6 +9668,7 @@
       "guid": "kGaI-255J9",
       "type": "Emote",
       "name": "Sneeze",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sneezing_Geographer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/SOTLP-Sneezing-Geographer.png"
     },
@@ -9406,6 +9711,7 @@
       "guid": "drH3NXwa4B",
       "type": "Emote",
       "name": "Hand-Rub",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Star_Collector#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/SOTLP-Star-Collector.png",
       "order": 821
@@ -9414,6 +9720,7 @@
       "guid": "kNbIj8-u0w",
       "type": "Emote",
       "name": "Hand-Rub",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Star_Collector#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/SOTLP-Star-Collector.png"
     },
@@ -9436,6 +9743,7 @@
       "guid": "kUOyMedcLK",
       "type": "Emote",
       "name": "Hand-Rub",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Star_Collector#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/SOTLP-Star-Collector.png"
     },
@@ -9443,6 +9751,7 @@
       "guid": "f2efm6-cUw",
       "type": "Emote",
       "name": "Hand-Rub",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Star_Collector#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/SOTLP-Star-Collector.png"
     },
@@ -9531,6 +9840,7 @@
       "guid": "mugeVvl6Vc",
       "type": "Emote",
       "name": "Navigate",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lively_Navigator#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Season_of_Flight_-_Lively_Navigator_icon.png",
       "order": 841
@@ -9539,6 +9849,7 @@
       "guid": "H6h0oeRVom",
       "type": "Emote",
       "name": "Navigate",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lively_Navigator#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Season_of_Flight_-_Lively_Navigator_icon.png"
     },
@@ -9576,6 +9887,7 @@
       "guid": "kkRo6gnuo9",
       "type": "Emote",
       "name": "Navigate",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lively_Navigator#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Season_of_Flight_-_Lively_Navigator_icon.png"
     },
@@ -9583,6 +9895,7 @@
       "guid": "VC9yqYv8O9",
       "type": "Emote",
       "name": "Navigate",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lively_Navigator#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Season_of_Flight_-_Lively_Navigator_icon.png"
     },
@@ -9781,6 +10094,7 @@
       "guid": "b_qHNPnLGc",
       "type": "Emote",
       "name": "Voilà",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Talented_Builder#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Season_of_Flight_-_voila_icon.png",
       "order": 831
@@ -9789,6 +10103,7 @@
       "guid": "zRFUMdaCAK",
       "type": "Emote",
       "name": "Voilà",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Talented_Builder#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Season_of_Flight_-_voila_icon.png"
     },
@@ -9824,6 +10139,7 @@
       "guid": "AlBQo1ngBi",
       "type": "Emote",
       "name": "Voilà",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Talented_Builder#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Season_of_Flight_-_voila_icon.png"
     },
@@ -9831,6 +10147,7 @@
       "guid": "0bY0v6h4ci",
       "type": "Emote",
       "name": "Voilà",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Talented_Builder#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Season_of_Flight_-_voila_icon.png"
     },
@@ -9871,6 +10188,7 @@
       "guid": "sk_cUbT6vx",
       "type": "Emote",
       "name": "Anxious",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Anxious_Angler#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/SOA-Anxious-Angler-emote.png",
       "order": 881
@@ -9879,6 +10197,7 @@
       "guid": "3ixBHha-wW",
       "type": "Emote",
       "name": "Anxious",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Anxious_Angler#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/SOA-Anxious-Angler-emote.png"
     },
@@ -9916,6 +10235,7 @@
       "guid": "kuS7q4u7Ua",
       "type": "Emote",
       "name": "Anxious",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Anxious_Angler#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/SOA-Anxious-Angler-emote.png"
     },
@@ -9923,6 +10243,7 @@
       "guid": "rv2ivbgqBM",
       "type": "Emote",
       "name": "Anxious",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Anxious_Angler#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/SOA-Anxious-Angler-emote.png"
     },
@@ -9967,6 +10288,7 @@
       "guid": "Ei9pBqI3yK",
       "type": "Emote",
       "name": "Calm Down",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ceasing_Commodore#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e8/SOA-Ceasing-Commodore-emote.png",
       "order": 851
@@ -9975,6 +10297,7 @@
       "guid": "FETTumn6J-",
       "type": "Emote",
       "name": "Calm Down",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ceasing_Commodore#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e8/SOA-Ceasing-Commodore-emote.png"
     },
@@ -10012,6 +10335,7 @@
       "guid": "aDDMg7WuIc",
       "type": "Emote",
       "name": "Calm Down",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ceasing_Commodore#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e8/SOA-Ceasing-Commodore-emote.png"
     },
@@ -10019,6 +10343,7 @@
       "guid": "TKVZD91Ur_",
       "type": "Emote",
       "name": "Calm Down",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ceasing_Commodore#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e8/SOA-Ceasing-Commodore-emote.png"
     },
@@ -10048,6 +10373,7 @@
       "guid": "VHBoJkhQ24",
       "type": "Emote",
       "name": "Ouch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bumbling_Boatswain#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/SOA-Bumbling-Boatswain-emote.png",
       "order": 871
@@ -10056,6 +10382,7 @@
       "guid": "ACcdP5GR4g",
       "type": "Emote",
       "name": "Ouch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bumbling_Boatswain#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/SOA-Bumbling-Boatswain-emote.png"
     },
@@ -10091,6 +10418,7 @@
       "guid": "qrYCS8SmH6",
       "type": "Emote",
       "name": "Ouch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bumbling_Boatswain#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/SOA-Bumbling-Boatswain-emote.png"
     },
@@ -10098,6 +10426,7 @@
       "guid": "-ccudc7_7b",
       "type": "Emote",
       "name": "Ouch",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bumbling_Boatswain#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/SOA-Bumbling-Boatswain-emote.png"
     },
@@ -10142,6 +10471,7 @@
       "guid": "d_Qmk0N-T9",
       "type": "Emote",
       "name": "Evil Laugh",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cackling_Cannoneer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/65/SOA-Cackling-Cannoneer-emote.png",
       "order": 861
@@ -10150,6 +10480,7 @@
       "guid": "0iyXmNvh_C",
       "type": "Emote",
       "name": "Evil Laugh",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cackling_Cannoneer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/65/SOA-Cackling-Cannoneer-emote.png"
     },
@@ -10185,6 +10516,7 @@
       "guid": "heGFa0OjPp",
       "type": "Emote",
       "name": "Evil Laugh",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cackling_Cannoneer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/65/SOA-Cackling-Cannoneer-emote.png"
     },
@@ -10192,6 +10524,7 @@
       "guid": "Vc0XWt8AUm",
       "type": "Emote",
       "name": "Evil Laugh",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cackling_Cannoneer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/65/SOA-Cackling-Cannoneer-emote.png"
     },
@@ -10256,6 +10589,7 @@
       "guid": "FmTG9TSX2e",
       "type": "Emote",
       "name": "Handshake",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frantic_Stagehand#Friend_Action" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4a/SoPerformance_-_Frantic_Stagehand-emote-icon-Morybel-0146.png"
     },
@@ -10297,6 +10631,7 @@
       "guid": "LYyK5T92ij",
       "type": "Emote",
       "name": "Handshake",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frantic_Stagehand#Friend_Action" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4a/SoPerformance_-_Frantic_Stagehand-emote-icon-Morybel-0146.png"
     },
@@ -10329,6 +10664,7 @@
       "guid": "atMtr23g93",
       "type": "Emote",
       "name": "Awww",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forgetful_Storyteller#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/SoPerformance_-_Forgetful_Storyteller-emote-icon-Morybel-0146.png",
       "order": 901
@@ -10337,6 +10673,7 @@
       "guid": "7tsa9wtqVi",
       "type": "Emote",
       "name": "Awww",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forgetful_Storyteller#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/SoPerformance_-_Forgetful_Storyteller-emote-icon-Morybel-0146.png"
     },
@@ -10374,6 +10711,7 @@
       "guid": "yiWOuxxWgB",
       "type": "Emote",
       "name": "Awww",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forgetful_Storyteller#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/SoPerformance_-_Forgetful_Storyteller-emote-icon-Morybel-0146.png"
     },
@@ -10381,6 +10719,7 @@
       "guid": "r6dNyY-aBP",
       "type": "Emote",
       "name": "Awww",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forgetful_Storyteller#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/SoPerformance_-_Forgetful_Storyteller-emote-icon-Morybel-0146.png"
     },
@@ -10425,6 +10764,7 @@
       "guid": "FWWMzSnh0A",
       "type": "Emote",
       "name": "Headbob",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mellow_Musician#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Morybel-0146-SoPerformance_-_Mellow_Musician-icon.png",
       "order": 891
@@ -10433,6 +10773,7 @@
       "guid": "EQQjcs9sT0",
       "type": "Emote",
       "name": "Headbob",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mellow_Musician#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Morybel-0146-SoPerformance_-_Mellow_Musician-icon.png"
     },
@@ -10470,6 +10811,7 @@
       "guid": "NXnXPRAcrO",
       "type": "Emote",
       "name": "Headbob",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mellow_Musician#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Morybel-0146-SoPerformance_-_Mellow_Musician-icon.png"
     },
@@ -10477,6 +10819,7 @@
       "guid": "3TnJKvu6Ga",
       "type": "Emote",
       "name": "Headbob",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mellow_Musician#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Morybel-0146-SoPerformance_-_Mellow_Musician-icon.png"
     },
@@ -10521,6 +10864,7 @@
       "guid": "kW5PsMdMVR",
       "type": "Emote",
       "name": "Duet Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Modest_Dancer#Friend_Action" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Morybel-0146-SOPerformance-Modest-Dancer-emote-icon.png"
     },
@@ -10562,6 +10906,7 @@
       "guid": "LTHqUonVhP",
       "type": "Emote",
       "name": "Duet Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Modest_Dancer#Friend_Action" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Morybel-0146-SOPerformance-Modest-Dancer-emote-icon.png"
     },
@@ -10832,6 +11177,7 @@
       "guid": "X_lxvfKdkA",
       "type": "Emote",
       "name": "Waving Light",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Running_Wayfarer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/SoAurora-Running-Wayfarer-Emote-Icon-Morybel-0146.png",
       "order": 911
@@ -10840,6 +11186,7 @@
       "guid": "JzE9JvMkF_",
       "type": "Emote",
       "name": "Waving Light",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Running_Wayfarer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/SoAurora-Running-Wayfarer-Emote-Icon-Morybel-0146.png"
     },
@@ -10877,6 +11224,7 @@
       "guid": "D0ERFYJm23",
       "type": "Emote",
       "name": "Waving Light",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Running_Wayfarer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/SoAurora-Running-Wayfarer-Emote-Icon-Morybel-0146.png"
     },
@@ -10884,6 +11232,7 @@
       "guid": "fW2OOpU5J-",
       "type": "Emote",
       "name": "Waving Light",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Running_Wayfarer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/SoAurora-Running-Wayfarer-Emote-Icon-Morybel-0146.png"
     },
@@ -10927,6 +11276,7 @@
       "guid": "CQGQ8vhjlp",
       "type": "Emote",
       "name": "Raise the Roof",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mindful_Miner#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/SoAurora-Mindful-Miner-Emote-Icon-Morybel-0146.png",
       "order": 921
@@ -10935,6 +11285,7 @@
       "guid": "wgHUFR0hL_",
       "type": "Emote",
       "name": "Raise the Roof",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mindful_Miner#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/SoAurora-Mindful-Miner-Emote-Icon-Morybel-0146.png"
     },
@@ -10957,6 +11308,7 @@
       "guid": "ZHoxzFOP4e",
       "type": "Emote",
       "name": "Raise the Roof",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mindful_Miner#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/SoAurora-Mindful-Miner-Emote-Icon-Morybel-0146.png"
     },
@@ -10964,6 +11316,7 @@
       "guid": "MOA-pspnfr",
       "type": "Emote",
       "name": "Raise the Roof",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mindful_Miner#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/SoAurora-Mindful-Miner-Emote-Icon-Morybel-0146.png"
     },
@@ -11024,6 +11377,7 @@
       "guid": "flYQ-k3_cR",
       "type": "Emote",
       "name": "Twirl",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Warrior_of_Love#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/61/SoAurora-Warrior-of-Love-Emote-Icon-Morybel-0146.png",
       "order": 931
@@ -11032,6 +11386,7 @@
       "guid": "84y87tOlc7",
       "type": "Emote",
       "name": "Twirl",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Warrior_of_Love#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/61/SoAurora-Warrior-of-Love-Emote-Icon-Morybel-0146.png"
     },
@@ -11069,6 +11424,7 @@
       "guid": "N_a1zpGl8Q",
       "type": "Emote",
       "name": "Twirl",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Warrior_of_Love#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/61/SoAurora-Warrior-of-Love-Emote-Icon-Morybel-0146.png"
     },
@@ -11076,6 +11432,7 @@
       "guid": "5QhZXNJtkv",
       "type": "Emote",
       "name": "Twirl",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Warrior_of_Love#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/61/SoAurora-Warrior-of-Love-Emote-Icon-Morybel-0146.png"
     },
@@ -11119,6 +11476,7 @@
       "guid": "LCZ4mS88Ml",
       "type": "Emote",
       "name": "Rhythmic Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Seed_of_Hope#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/SoAurora-Seed-of-Hope-Emote-Icon-Morybel-0146.png",
       "order": 941
@@ -11127,6 +11485,7 @@
       "guid": "Xp7ou1f01j",
       "type": "Emote",
       "name": "Rhythmic Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Seed_of_Hope#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/SoAurora-Seed-of-Hope-Emote-Icon-Morybel-0146.png"
     },
@@ -11162,6 +11521,7 @@
       "guid": "9cv6EvVG5z",
       "type": "Emote",
       "name": "Rhythmic Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Seed_of_Hope#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/SoAurora-Seed-of-Hope-Emote-Icon-Morybel-0146.png"
     },
@@ -11169,6 +11529,7 @@
       "guid": "5qPaiJyODI",
       "type": "Emote",
       "name": "Rhythmic Clap",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Seed_of_Hope#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/SoAurora-Seed-of-Hope-Emote-Icon-Morybel-0146.png"
     },
@@ -11284,15 +11645,17 @@
     },
     {
       "guid": "T71hdAEX-_",
-      "name": "Cure for Me",
       "type": "Emote",
+      "name": "Cure for Me",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Encore_Concerts#Cure_for_Me_Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/79/AURORA-Cure-for-Me-expression-icon-Credit-Morybel.png"
     },
     {
       "guid": "nNSNKcR0jV",
-      "name": "Cure for Me",
       "type": "Emote",
+      "name": "Cure for Me",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Encore_Concerts#Cure_for_Me_Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/79/AURORA-Cure-for-Me-expression-icon-Credit-Morybel.png"
     },
@@ -11304,6 +11667,7 @@
       "guid": "8PJqQ9WsHo",
       "type": "Emote",
       "name": "Grieving",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bereft_Veteran#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/SoRemembrance-Bereft-Veteran-Emote-Icon-Morybel-0146.png",
       "order": 1001
@@ -11312,6 +11676,7 @@
       "guid": "ms8gAS7UHk",
       "type": "Emote",
       "name": "Grieving",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bereft_Veteran#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/SoRemembrance-Bereft-Veteran-Emote-Icon-Morybel-0146.png"
     },
@@ -11349,6 +11714,7 @@
       "guid": "FIaYs2Unva",
       "type": "Emote",
       "name": "Grieving",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bereft_Veteran#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/SoRemembrance-Bereft-Veteran-Emote-Icon-Morybel-0146.png"
     },
@@ -11356,6 +11722,7 @@
       "guid": "Wu1J2yazsw",
       "type": "Emote",
       "name": "Grieving",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bereft_Veteran#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/SoRemembrance-Bereft-Veteran-Emote-Icon-Morybel-0146.png"
     },
@@ -11385,6 +11752,7 @@
       "guid": "6H4WC7Aipv",
       "type": "Emote",
       "name": "Pleading",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/66/SoRemembrance-Pleading-Child-Emote-Icon-Morybel-0146.png",
       "order": 981
@@ -11393,6 +11761,7 @@
       "guid": "oxlHVEQ-KD",
       "type": "Emote",
       "name": "Pleading",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/66/SoRemembrance-Pleading-Child-Emote-Icon-Morybel-0146.png"
     },
@@ -11430,6 +11799,7 @@
       "guid": "LWXpz1a8d_",
       "type": "Emote",
       "name": "Pleading",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/66/SoRemembrance-Pleading-Child-Emote-Icon-Morybel-0146.png"
     },
@@ -11437,6 +11807,7 @@
       "guid": "xiAEktyuKT",
       "type": "Emote",
       "name": "Pleading",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/66/SoRemembrance-Pleading-Child-Emote-Icon-Morybel-0146.png"
     },
@@ -11475,6 +11846,7 @@
       "guid": "8Pr0VtDhsh",
       "type": "Emote",
       "name": "Tiptoeing",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tiptoeing_Tea-Brewer#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/SoRemembrance-Tiptoeing-Tea-Brewer-Emote-Icon-Morybel-0146.png",
       "order": 991
@@ -11483,6 +11855,7 @@
       "guid": "-XSUgHYCU-",
       "type": "Emote",
       "name": "Tiptoeing",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tiptoeing_Tea-Brewer#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/SoRemembrance-Tiptoeing-Tea-Brewer-Emote-Icon-Morybel-0146.png"
     },
@@ -11505,6 +11878,7 @@
       "guid": "ilnoN5oAS7",
       "type": "Emote",
       "name": "Tiptoeing",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tiptoeing_Tea-Brewer#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/SoRemembrance-Tiptoeing-Tea-Brewer-Emote-Icon-Morybel-0146.png"
     },
@@ -11512,6 +11886,7 @@
       "guid": "S3meQvWoGC",
       "type": "Emote",
       "name": "Tiptoeing",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tiptoeing_Tea-Brewer#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/SoRemembrance-Tiptoeing-Tea-Brewer-Emote-Icon-Morybel-0146.png"
     },
@@ -11617,6 +11992,7 @@
       "guid": "q1lSh8QVkN",
       "type": "Emote",
       "name": "Hacky sack",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Oddball_Outcast#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Passage-Oddball-Outcast-Emote-icon-Morybel-0146.png",
       "order": 1011
@@ -11625,6 +12001,7 @@
       "guid": "WMCReW0LQD",
       "type": "Emote",
       "name": "Hacky sack",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Oddball_Outcast#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Passage-Oddball-Outcast-Emote-icon-Morybel-0146.png"
     },
@@ -11662,6 +12039,7 @@
       "guid": "kQ7Yvu-g4k",
       "type": "Emote",
       "name": "Hacky sack",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Oddball_Outcast#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Passage-Oddball-Outcast-Emote-icon-Morybel-0146.png"
     },
@@ -11669,6 +12047,7 @@
       "guid": "piGSeoIPd_",
       "type": "Emote",
       "name": "Hacky sack",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Oddball_Outcast#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Passage-Oddball-Outcast-Emote-icon-Morybel-0146.png"
     },
@@ -11698,6 +12077,7 @@
       "guid": "FEzWv1XXku",
       "type": "Emote",
       "name": "Somersault",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Passage-Tumbling-Troublemaker-Emote-icon-Morybel-0146.png",
       "order": 1021
@@ -11706,6 +12086,7 @@
       "guid": "DjPVeBb0wn",
       "type": "Emote",
       "name": "Somersault",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Passage-Tumbling-Troublemaker-Emote-icon-Morybel-0146.png"
     },
@@ -11728,6 +12109,7 @@
       "guid": "IxNpykF933",
       "type": "Emote",
       "name": "Somersault",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Passage-Tumbling-Troublemaker-Emote-icon-Morybel-0146.png"
     },
@@ -11735,6 +12117,7 @@
       "guid": "Gnl7Kf2xWO",
       "type": "Emote",
       "name": "Somersault",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Passage-Tumbling-Troublemaker-Emote-icon-Morybel-0146.png"
     },
@@ -11779,6 +12162,7 @@
       "guid": "Z9YH4KCszX",
       "type": "Emote",
       "name": "Moping",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Passage-Melancholy-Mope-Emote-icon-Morybel-0146.png",
       "order": 1031
@@ -11787,6 +12171,7 @@
       "guid": "ozw69gqvhQ",
       "type": "Emote",
       "name": "Moping",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Passage-Melancholy-Mope-Emote-icon-Morybel-0146.png"
     },
@@ -11824,6 +12209,7 @@
       "guid": "AZb8ZxAeDb",
       "type": "Emote",
       "name": "Moping",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Passage-Melancholy-Mope-Emote-icon-Morybel-0146.png"
     },
@@ -11831,6 +12217,7 @@
       "guid": "9v4_Si1oJn",
       "type": "Emote",
       "name": "Moping",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Passage-Melancholy-Mope-Emote-icon-Morybel-0146.png"
     },
@@ -11860,6 +12247,7 @@
       "guid": "7aW4_cS3Ob",
       "type": "Emote",
       "name": "Pull-up",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Overactive_Overachiever#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/Passage-Overactive-Overachiever-Emote-icon-Morybel-0146.png",
       "order": 1041
@@ -11868,6 +12256,7 @@
       "guid": "nRbYecsrpX",
       "type": "Emote",
       "name": "Pull-up",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Overactive_Overachiever#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/Passage-Overactive-Overachiever-Emote-icon-Morybel-0146.png"
     },
@@ -11890,6 +12279,7 @@
       "guid": "BwA9_RCi47",
       "type": "Emote",
       "name": "Pull-up",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Overactive_Overachiever#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/Passage-Overactive-Overachiever-Emote-icon-Morybel-0146.png"
     },
@@ -11897,6 +12287,7 @@
       "guid": "bs7ZBPqzge",
       "type": "Emote",
       "name": "Pull-up",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Overactive_Overachiever#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/Passage-Overactive-Overachiever-Emote-icon-Morybel-0146.png"
     },
@@ -11943,6 +12334,7 @@
       "guid": "DLJd5rdOFB",
       "type": "Emote",
       "name": "Side Hug",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Reassuring_Ranger#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/Reassuring-Ranger-Action-icon-Credit-Morybel.png"
     },
@@ -11950,6 +12342,7 @@
       "guid": "qwdvtBnaPL",
       "type": "Emote",
       "name": "Side Hug",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Reassuring_Ranger#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/Reassuring-Ranger-Action-icon-Credit-Morybel.png"
     },
@@ -12025,6 +12418,7 @@
       "guid": "X8TxVCwAoY",
       "type": "Emote",
       "name": "Jolly Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jolly_Geologist#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/Jolly-Geologist-Emote-icon-Credit-Morybel.png"
     },
@@ -12032,6 +12426,7 @@
       "guid": "zPG9h4NM2q",
       "type": "Emote",
       "name": "Jolly Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jolly_Geologist#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/Jolly-Geologist-Emote-icon-Credit-Morybel.png"
     },
@@ -12057,6 +12452,7 @@
       "guid": "5_eEcizGMw",
       "type": "Emote",
       "name": "Jolly Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jolly_Geologist#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/Jolly-Geologist-Emote-icon-Credit-Morybel.png"
     },
@@ -12064,6 +12460,7 @@
       "guid": "xlEzjV6XFr",
       "type": "Emote",
       "name": "Jolly Dance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jolly_Geologist#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/Jolly-Geologist-Emote-icon-Credit-Morybel.png"
     },
@@ -12107,6 +12504,7 @@
       "guid": "VASzthgEAN",
       "type": "Emote",
       "name": "Blindfold Balance Pose",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ascetic_Monk#Expression" },
       "level": 1,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/Ascetic-Monk-Emote-icon-Credit-Morybel.png"
     },
@@ -12114,6 +12512,7 @@
       "guid": "PkVcGrnkjj",
       "type": "Emote",
       "name": "Blindfold Balance Pose",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ascetic_Monk#Expression" },
       "level": 2,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/Ascetic-Monk-Emote-icon-Credit-Morybel.png"
     },
@@ -12151,6 +12550,7 @@
       "guid": "jC14SXIUVC",
       "type": "Emote",
       "name": "Blindfold Balance Pose",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ascetic_Monk#Expression" },
       "level": 3,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/Ascetic-Monk-Emote-icon-Credit-Morybel.png"
     },
@@ -12158,6 +12558,7 @@
       "guid": "fy4bnUxzOX",
       "type": "Emote",
       "name": "Blindfold Balance Pose",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ascetic_Monk#Expression" },
       "level": 4,
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/Ascetic-Monk-Emote-icon-Credit-Morybel.png"
     },

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -8304,6 +8304,8 @@
       "type": "Shoes",
       "name": "Chuckling Scout Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/Chuckling-Scout-shoes-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/36/Chuckling-Scout-shoes.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Shoes" },
       "order": 1
     },
     {
@@ -10558,6 +10560,8 @@
       "type": "Shoes",
       "name": "AURORA Musical Voyage Sneakers",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4c/Aurora-Record-Breaker-Sneakers-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/39/Musical-Voyage-Sneakers.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA#AURORA's_Musical_Voyage_Sneakers" },
       "order": 601
     },
     {
@@ -10722,6 +10726,8 @@
       "type": "Shoes",
       "name": "Pleading Child Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/50/Pleading-Child-Shoes-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Pleading-Child-Shoes.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Shoes" },
       "order": 101
     },
     {
@@ -11462,6 +11468,8 @@
       "type": "Shoes",
       "name": "Nightbird Whisperer Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Nightbird-Whisperer-Footwear-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/30/Nightbird-Whisperer-Footwear.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nightbird_Whisperer#Shoes" },
       "order": 201
     },
     {
@@ -12280,6 +12288,8 @@
       "name": "Style Bunny Slippers",
       "type": "Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b4/Style-Bunny-Slippers-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1d/Style-Bunny-Slippers.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Style#Style_Bunny_Slippers" },
       "order": 502
     },
     {
@@ -12305,6 +12315,8 @@
       "name": "Style Silk Ballet Slippers",
       "type": "Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/Ballet-Flats-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1b/Ballet-Flats.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Style#Style_Silk_Ballet_Slippers" },
       "order": 501
     },
     {
@@ -12428,6 +12440,8 @@
       "type": "Shoes",
       "name": "Mischief Witch Jumper Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Mischief-Witch-Jumper-Shoes-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Mischief-Witch-Jumper-Shoes.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Jumper_Shoes" },
       "order": 301
     },
     {
@@ -12786,6 +12800,8 @@
       "name": "Sunlight Chunky Sandals",
       "type": "Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/69/Sunlight-Chunky-Sandals-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e7/Sunlight-Chunky-Sandals.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Chunky_Sandals" },
       "order": 401
     },
     {

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -265,6 +265,8 @@
       "type": "FaceAccessory",
       "name": "Rejecting Voyager Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bc/RejectingVoyager-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Mask02-Simple_horizontal.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rejecting_Voyager#Mask" },
       "order": 1
     },
     {
@@ -729,6 +731,8 @@
       "type": "FaceAccessory",
       "name": "Exhausted Dock Worker Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e4/ExhaustedDockWorker-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/Mask04.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Exhausted_Dock_Worker#Mask" },
       "order": 2
     },
     // Ceremonial Worshiper
@@ -1196,6 +1200,8 @@
       "type": "FaceAccessory",
       "name": "Apologetic Lumberjack Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1b/ApologeticLumberjack-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Mask05-Diamond.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Apologetic_Lumberjack#Mask" },
       "order": 3
     },
     // Tearful Light Miner
@@ -1533,6 +1539,8 @@
       "type": "FaceAccessory",
       "name": "Backflipping Champion Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/BackflippingChampion-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Mask08.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Backflipping_Champion#Mask" },
       "order": 5
     },
     // Cheerful Spectator
@@ -1669,6 +1677,8 @@
       "type": "FaceAccessory",
       "name": "Bowing Medalist Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/53/BowingMedalist-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/Mask09.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bowing_Medalist#Mask" },
       "order": 4
     },
     // Proud Victor
@@ -2124,6 +2134,8 @@
       "type": "FaceAccessory",
       "name": "Lookout Scout Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/LookoutScout-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Mask11.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lookout_Scout#Mask" },
       "order": 6
     },
     // #endregion
@@ -2194,6 +2206,8 @@
       "type": "FaceAccessory",
       "name": "Levitating Adept Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/LevitatingAdept-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Mask12-Long_Panel.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Levitating_Adept#Mask" },
       "order": 7
     },
     // Meditating Monastic
@@ -2472,6 +2486,8 @@
       "group": "Elder",
       "name": "Isle Elder Ultimate Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/Elder-Mask-Icon-Isle-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/00/Elder-Mask-Isle-original-Credit-Nastymold.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Isle_Elder#Mask" },
       "order": 51
     },
     // Prairie Elder
@@ -2489,6 +2505,8 @@
       "group": "Elder",
       "name": "Prairie Elder Ultimate Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Elder-Mask-Icon-Prairie-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Elder-Mask-Prairie-original-Credit-Nastymold.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prairie_Elder#Mask" },
       "order": 52
     },
     // Forest Elder
@@ -2506,6 +2524,8 @@
       "group": "Elder",
       "name": "Forest Elder Ultimate Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/Elder-Mask-Icon-Forest-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Elder-Mask-Forest-original-Credit-Nastymold.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forest_Elder#Mask" },
       "order": 53
     },
     // Valley Elders
@@ -2645,6 +2665,8 @@
       "group": "Ultimate",
       "name": "Enchantment Ultimate Hair Tassels",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Icon_hair_enchantment_ultimate_tassles.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/Season_of_enchantment_ultimate_tassels_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Enchantment_Guide#Ultimate_Gifts" },
       "order": 1001
     },
     {
@@ -3406,6 +3428,8 @@
       "type": "FaceAccessory",
       "name": "Abyss Ultimate Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ab/SOAbyss-Ultime-gift-hair-tassle.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/SOAbyss-Ultime-gift-hair-tassle-screenshot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Abyss_Guide#Ultimate_Gifts" },
       "order": 1201
     },
     {
@@ -4369,6 +4393,8 @@
       "name": "Moments Ultimate Glasses",
       "group": "Ultimate",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Moments-Guide-Head-accessory-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/33/Moments-Guide-Head-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Moments_Guide#Ultimate_Gifts" },
       "order": 901
     },
     {
@@ -5698,6 +5724,8 @@
       "type": "FaceAccessory",
       "name": "Hairtousle Teen Earmuffs",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/12/Mimi-4117_04_hairtousle_teen_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/Belonging_Headgear_Forest_Ear_Muffs.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hairtousle_Teen#Hair_Accessory" },
       "order": 1701
     },
     {
@@ -7180,6 +7208,8 @@
       "type": "FaceAccessory",
       "name": "Chill Sunbather Sunglasses",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/Mimi-4117_07_chill_sunbather_mask.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Season_of_sanctuary_mask_chill_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chill_Sunbather#Mask" },
       "order": 601
     },
     {
@@ -7671,6 +7701,8 @@
       "type": "FaceAccessory",
       "name": "Bearhug Hermit Horns",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/Icon_hair_dreams_hermit_horns.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/19/Dreams_headpiece_bearhug_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bearhug_Hermit#Hair_Accessory" },
       "order": 1101
     },
     {
@@ -10649,6 +10681,8 @@
       "type": "FaceAccessory",
       "name": "Tiara We Can Touch",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/Aurora-Hair-Accessory-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9d/SoAurora-Hair-Accessory-no-hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Hair_Accessory" },
       "order": 1301
     },
     {
@@ -11166,6 +11200,8 @@
       "type": "FaceAccessory",
       "name": "Tumbling Troublemaker Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Passage-Tumbling-Troublemaker-Hair-Accessory-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/Passage-Tumbling-Troublemaker-Hair-Accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Hair_Accessory" },
       "order": 1402
     },
     {
@@ -11195,6 +11231,8 @@
       "type": "FaceAccessory",
       "name": "Melancholy Mope Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Passage-Melancholy-Mope-Hair-accessory-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Passage-Melancholy-Mope-Hair-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Hair_Accessory" },
       "order": 1401
     },
     {
@@ -11354,6 +11392,8 @@
       "type": "FaceAccessory",
       "name": "Reassuring Ranger Wheat Stalk",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/20/Reassuring-Ranger-Head-accessory-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/Reassuring-Ranger-Head-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Reassuring_Ranger#Face_Accessory" },
       "order": 1501
     },
     {
@@ -11424,6 +11464,8 @@
       "type": "FaceAccessory",
       "name": "Jolly Geologist Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Jolly-Geologist-Head-accessory-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Jolly-Geologist-Head-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jolly_Geologist#Face_Accessory" },
       "order": 1502
     },
     {
@@ -12079,6 +12121,8 @@
       "type": "FaceAccessory",
       "name": "Nature Glasses",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/16/Days-of-Nature-Glasses-icon-Ray.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/89/Days-of-Nature-Glasses.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Nature_Glasses" },
       "order": 801
     },
     {
@@ -12095,6 +12139,8 @@
       "type": "FaceAccessory",
       "name": "Rainbow Braid",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8f/Icon_hair_rainbow_tassle.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/Rainbow_tassle_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Rainbow_Braid" },
       "order": 1601
     },
     {
@@ -12208,6 +12254,8 @@
       "type": "FaceAccessory",
       "name": "Rainbow Earrings",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4b/Days-of-Rainbow-2022-earring-accessory-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Days-of-Rainbow-2022-earring-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Rainbow_Earring" },
       "order": 1602
     },
     {
@@ -12215,6 +12263,8 @@
       "type": "FaceAccessory",
       "name": "Rainbow Headphones",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/Days_of_Rainbow_2022-_headphones-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/Days_of_Rainbow_2022-_headphones.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Rainbow_Headphones" },
       "order": 1801
     },
     {
@@ -12258,6 +12308,8 @@
       "type": "FaceAccessory",
       "name": "Dark Rainbow Earrings",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/21/Days-of-Colors-Dark-Rainbow-Earring-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5c/Days-of-Colors-Dark-Rainbow-Earring.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Dark_Rainbow_Earrings" },
       "order": 1603
     },
     {
@@ -12456,19 +12508,28 @@
       "guid": "3HeVKqT39a",
       "name": "Style Heart Sunglasses",
       "type": "FaceAccessory",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3f/Style-Heart-Sunglasses-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3f/Style-Heart-Sunglasses-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/Style-Heart-Sunglasses.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Style#Style_Heart_Sunglasses" },
+      "order": 853
     },
     {
       "guid": "BWUjIgnjnu",
       "name": "Style Flame Sunglasses",
       "type": "FaceAccessory",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/Style-Flame-Sunglasses-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/Style-Flame-Sunglasses-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Style-Flame-Sunglasses.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Style#Style_Flame_Sunglasses" },
+      "order": 852
     },
     {
       "guid": "qscApTevys",
       "name": "Style Star Sunglasses",
       "type": "FaceAccessory",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Style-Star-Sunglasses-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Style-Star-Sunglasses-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/19/Style-Star-Sunglasses.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Style#Style_Star_Sunglasses" },
+      "order": 851
     },
     {
       "guid": "d_p_flDgEV",
@@ -12612,6 +12673,8 @@
       "type": "FaceAccessory",
       "name": "Mischief Withered Antlers",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Icon_2021_mischief_headpiece.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Hair_2021_mischief_headpiece_iap.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Withered_Antlers" },
       "order": 2001
     },
     {
@@ -12658,6 +12721,8 @@
       "type": "FaceAccessory",
       "name": "Days of Feast Horns",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/93/Icon_hair_feast_antlers.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/Antlers_headpiece_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Days_of_Feast_Horns" },
       "order": 1901
     },
     {
@@ -12789,6 +12854,8 @@
       "type": "FaceAccessory",
       "name": "Feast Goggles",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/Days-of-Feast-Yeti-Goggles-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/Days-of-Feast-Yeti-Goggles.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Feast_Goggles" },
       "order": 701
     },
     {

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -2573,6 +2573,8 @@
       "group": "Ultimate",
       "name": "Gratitude Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/1_Gratitude.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/Gratitude_pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Gratitude_Guide#Ultimate_Gifts" },
       "order": 1
     },
     {
@@ -2593,6 +2595,8 @@
       "group": "Ultimate",
       "name": "Lightseekers Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/51/2_Lightseekers.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c8/Lightseekers_pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lightseekers_Guide#Ultimate_Gifts" },
       "order": 2
     },
     {
@@ -2611,6 +2615,8 @@
       "group": "Ultimate",
       "name": "Belonging Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dc/3_Belonging.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/60/Season_of_belonging_pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Belonging_Guide#Ultimate_Gifts" },
       "order": 3
     },
     {
@@ -2629,6 +2635,8 @@
       "group": "Ultimate",
       "name": "Rhythm Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/4_Rhythm.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e2/Season_of_rhythm_pendant_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rhythm_Guide#Ultimate_Gifts" },
       "order": 4
     },
     {
@@ -2657,6 +2665,8 @@
       "group": "Ultimate",
       "name": "Enchantment Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e8/5_Enchantment.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/60/Season_of_enchantment_pendant_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Enchantment_Guide#Ultimate_Gifts" },
       "order": 5
     },
     {
@@ -2763,6 +2773,8 @@
       "group": "Ultimate",
       "name": "Sanctuary Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a4/6_Sanctuary.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/96/Season_of_sanctuary_sanctuary_pendant_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sanctuary_Guide#Ultimate_Gifts" },
       "order": 6
     },
     {
@@ -2867,6 +2879,8 @@
       "group": "Ultimate",
       "name": "Prophecy Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/76/7_Prophecy.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/49/Prophecy_pendant_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophecy_Guide#Ultimate_Gifts" },
       "order": 7
     },
     {
@@ -2949,6 +2963,8 @@
       "name": "Dreams Pendant",
       "group": "Ultimate",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a7/8_Dreams.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f2/Dreams_pendant_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dreams_Guide#Ultimate_Gifts" },
       "order": 8
     },
     {
@@ -3043,6 +3059,8 @@
       "group": "Ultimate",
       "name": "Assembly Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/9_Assembly.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fb/Assembly_pendant_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Ultimate_Gifts" },
       "order": 9
     },
     {
@@ -3194,6 +3212,8 @@
       "group": "Ultimate",
       "name": "The Little Prince Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/20/10_Little_Prince.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bc/Little_prince_pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Rose#Ultimate_Gifts" },
       "order": 10
     },
     {
@@ -3323,6 +3343,8 @@
       "group": "Ultimate",
       "name": "Flight Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/41/11_Flight.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3f/Season_of_flight_pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Flight_Guide#Ultimate_Gifts" },
       "order": 11
     },
     {
@@ -3421,6 +3443,8 @@
       "group": "Ultimate",
       "name": "Abyss Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/12_Abyss.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/SOAbyss-Pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Abyss_Guide#Ultimate_Gifts" },
       "order": 12
     },
     {
@@ -3531,6 +3555,8 @@
       "group": "Ultimate",
       "name": "Performance Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/16/13_SOPerformance_logo.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/34/SOPerformance-pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Performance_Guide#Ultimate_Gifts" },
       "order": 13
     },
     {
@@ -3688,6 +3714,8 @@
       "group": "Ultimate",
       "name": "Shattering Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/14_SOShattering.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/76/SOShattering-pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Void_of_Shattering#Ultimate_Gifts" },
       "order": 14
     },
     {
@@ -3796,6 +3824,8 @@
       "group": "Ultimate",
       "name": "AURORA Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3a/15-Aurora.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/SoAurora-Seasonal-Pass-pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Ultimate_Gifts" },
       "order": 15
     },
     {
@@ -3990,6 +4020,8 @@
       "group": "Ultimate",
       "name": "Remembrance Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/16_SORemembrance_logo.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/SoRemembrance-Seasonal-Pass-pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Ultimate_Gifts" },
       "order": 16
     },
     {
@@ -3997,6 +4029,8 @@
       "type": "Necklace",
       "name": "Remembrance Ultimate Sash",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/SoRemembrance-Ultimate-Gift-Sash-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/SoRemembrance-Ultimate-Gift-Sash.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Ultimate_Gifts" },
       "order": 1602
     },
     {
@@ -4279,6 +4313,8 @@
       "group": "Ultimate",
       "name": "Passage Pendant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/17_SOPassage_logo.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c7/Passage-Seasonal-pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Passage_Guide#Ultimate_Gifts" },
       "order": 17
     },
     {
@@ -4385,6 +4421,8 @@
       "name": "Moments Pendant",
       "group": "Ultimate",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5c/Season-of-Moments-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f4/Moments-Guide-Pendant.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Moments_Guide#Ultimate_Gifts" },
       "order": 18
     },
     {
@@ -7080,6 +7118,8 @@
       "type": "Necklace",
       "name": "Hiking Grouch Bowtie",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/Icon_pendant_bowtie.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9e/Season_of_sanctuary_sanctuary_grouch_bowtie_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Neck_Accessory" },
       "order": 601
     },
     {
@@ -8988,6 +9028,8 @@
       "type": "Necklace",
       "name": "Star Collector Neckpiece",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/33/Icon_pendant_little_prince_neckerchief.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/Season_of_little_prince_necktie.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Star_Collector#Neck_Accessory" },
       "order": 1001
     },
     {
@@ -9346,6 +9388,8 @@
       "type": "Necklace",
       "name": "Talented Builder Neckpiece",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/Icon_season_of_flight_neckpiece_talented_builder.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/Season_of_flight_neckpiece_talented_builder.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Talented_Builder#Neck_Accessory" },
       "order": 1101
     },
     {
@@ -10265,8 +10309,10 @@
     {
       "guid": "w2bnlVRUvy",
       "type": "Necklace",
-      "name": "Dragon Necklace",
+      "name": "Dragon Neck Accessory (Crab)",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ee/SOShattering-Dark-Crab-neck-accessory-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/SOShattering-Dark-Crab-neck-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Darkness#Neck_Accessory" },
       "order": 1401
     },
     {
@@ -10853,8 +10899,10 @@
     {
       "guid": "-uVJsYJF-Z",
       "type": "Necklace",
-      "name": "Pleading Child Necklace",
+      "name": "Pleading Child Scarf",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/SoRemembrance-Pleading-Child-Necklace-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dc/SoRemembrance-Pleading-Child-Necklace.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Neck_Accessory" },
       "order": 1601
     },
     {
@@ -11096,6 +11144,8 @@
       "type": "Necklace",
       "name": "Oddball Outcast Neckpiece",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d7/Passage-Oddball-Outcast-neck-accessory-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/56/Passage-Oddball-Outcast-neck-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Oddball_Outcast#Neck_Accessory" },
       "order": 1701
     },
     {
@@ -11906,6 +11956,8 @@
       "type": "Necklace",
       "name": "Days of Love Classy Cravat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/Days-of-Love-Neck-Bow-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/Days-of-Love-Classy-Cravat.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love#Days_of_Love_Classy_Cravat" },
       "order": 10101
     },
     {
@@ -12067,6 +12119,8 @@
       "type": "Necklace",
       "name": "Ocean Necklace",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/70/Icon_pendant_shell_pendant.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Shell_necklace.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Ocean_Necklace" },
       "order": 10301
     },
     {
@@ -12088,6 +12142,8 @@
       "type": "Necklace",
       "name": "Nature Turtle Buddy",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Days-of-Nature-2022-turtle-accessory-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/00/Days-of-Nature-2022-turtle-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Nature_Turtle_Accessory" },
       "order": 10501
     },
     {
@@ -12751,6 +12807,8 @@
       "type": "Necklace",
       "name": "Feast Necktie",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Icon_pendant_holly_pendant.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/ff/Holly_necklace_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Feast_Necktie" },
       "order": 10602
     },
     {
@@ -12802,6 +12860,8 @@
       "type": "Necklace",
       "name": "Winter Feast Scarf",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dc/Days_of_Feast_Scarf_icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/Feast_Scarf.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Winter_Feast_Scarf" },
       "order": 10601
     },
     {
@@ -12979,6 +13039,8 @@
       "type": "Necklace",
       "name": "Jelly Shoulder Buddy",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/96/Days-of-Sunlight-Jellyfish-Neck-Accessory-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Days-of-Sunlight-Jellyfish-accessory-image.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Jelly_Shoulder_Buddy" },
       "order": 10401
     },
     {

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -2599,7 +2599,7 @@
       "name": "Isle Elder Ultimate Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/Elder-Mask-Icon-Isle-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/00/Elder-Mask-Isle-original-Credit-Nastymold.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Isle_Elder#Mask" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Isle_Elder#Face_Accessory" },
       "order": 51
     },
     // Prairie Elder
@@ -2620,7 +2620,7 @@
       "name": "Prairie Elder Ultimate Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Elder-Mask-Icon-Prairie-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Elder-Mask-Prairie-original-Credit-Nastymold.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prairie_Elder#Mask" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prairie_Elder#Face_Accessory" },
       "order": 52
     },
     // Forest Elder
@@ -2641,7 +2641,7 @@
       "name": "Forest Elder Ultimate Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/Elder-Mask-Icon-Forest-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Elder-Mask-Forest-original-Credit-Nastymold.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forest_Elder#Mask" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forest_Elder#Face_Accessory" },
       "order": 53
     },
     // Valley Elders
@@ -3702,7 +3702,7 @@
       "name": "Abyss Guide Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e6/SOAbyss-additional-mask-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/SOAbyss-mask2.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Abyss_Guide#Mask" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Abyss_Guide#Oxygen_Mask" },
       "order": 1205
     },
     // #endregion
@@ -3894,7 +3894,7 @@
       "name": "Shattering Ultimate Manta Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/SOShattering-ultimate-Cape-manta-Icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/SOShattering-ultimate-Cape-manta-bac.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Void_of_Shattering#Cape" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Void_of_Shattering#Ultimate_Gifts" },
       "order": 2405
     },
     {
@@ -3903,7 +3903,7 @@
       "name": "Shattering Ultimate Krill Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/98/SOShattering-ultimate-Cape-krill-Icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/SOShattering-ultimate-Cape-krill-back.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Void_of_Shattering#Cape" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Void_of_Shattering#Ultimate_Gifts" },
       "order": 2402
     },
     {
@@ -4535,7 +4535,7 @@
       "name": "Camera",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/23/Moments-Guide-Prop-Camera-icon-Credit-Morybel.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Moments-Guide-Prop-Camera.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Moments_Guide#Prop" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Moments_Guide#Camera_Prop" },
       "order": 4001
     },
     {
@@ -6017,7 +6017,7 @@
       "name": "Hairtousle Teen Earmuffs",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/12/Mimi-4117_04_hairtousle_teen_hat.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/Belonging_Headgear_Forest_Ear_Muffs.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hairtousle_Teen#Hair_Accessory" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hairtousle_Teen#Face_Accessory" },
       "order": 1701
     },
     {
@@ -8086,7 +8086,7 @@
       "name": "Bearhug Hermit Horns",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/Icon_hair_dreams_hermit_horns.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/19/Dreams_headpiece_bearhug_v2.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bearhug_Hermit#Hair_Accessory" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bearhug_Hermit#Face_Accessory" },
       "order": 1101
     },
     {
@@ -9520,7 +9520,7 @@
       "name": "Little Prince Fox",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6c/Icon_prop_little_prince_fox.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/Season_of_little_prince_iap_fox_inst.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Rose#Prop" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_The_Little_Prince#Little_Prince_Fox_Prop" },
       "order": 2301
     },
     // #endregion
@@ -11216,7 +11216,7 @@
       "name": "Tiara We Can Touch",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/Aurora-Hair-Accessory-icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9d/SoAurora-Hair-Accessory-no-hair.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Hair_Accessory" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_AURORA#Tiara_We_Can_Touch" },
       "order": 1301
     },
     {
@@ -11225,7 +11225,7 @@
       "name": "AURORA Runaway Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/62/Aurora-Runaway-Hair-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/SoAurora-Short-bang-hairstyle.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Hair" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_AURORA#Runaway_Hair" },
       "order": 2505
     },
     {
@@ -11279,7 +11279,7 @@
       "name": "AURORA Musical Voyage Sneakers",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4c/Aurora-Record-Breaker-Sneakers-icon-Credit-Morybel.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/39/Musical-Voyage-Sneakers.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA#AURORA's_Musical_Voyage_Sneakers" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Encore_Concerts#Musical_Voyage_Sneakers" },
       "order": 601
     },
     {
@@ -11455,7 +11455,7 @@
       "name": "Pleading Child Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/50/Pleading-Child-Shoes-icon-Credit-Morybel.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Pleading-Child-Shoes.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Shoes" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Outfit" },
       "order": 101
     },
     {
@@ -11765,7 +11765,7 @@
       "name": "Tumbling Troublemaker Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Passage-Tumbling-Troublemaker-Hair-Accessory-icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/Passage-Tumbling-Troublemaker-Hair-Accessory.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Hair_Accessory" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Face_Accessory" },
       "order": 1402
     },
     {
@@ -11796,7 +11796,7 @@
       "name": "Melancholy Mope Face Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Passage-Melancholy-Mope-Hair-accessory-icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Passage-Melancholy-Mope-Hair-accessory.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Hair_Accessory" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Face_Accessory" },
       "order": 1401
     },
     {
@@ -12967,7 +12967,7 @@
       "name": "Dark Rainbow Earrings",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/21/Days-of-Colors-Dark-Rainbow-Earring-icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5c/Days-of-Colors-Dark-Rainbow-Earring.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Dark_Rainbow_Earrings" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color#Dark_Rainbow_Earring_Pack" },
       "order": 1603
     },
     {
@@ -13368,7 +13368,7 @@
       "name": "Mischief Witch Jumper Shoes",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Mischief-Witch-Jumper-Shoes-icon-Credit-Morybel.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Mischief-Witch-Jumper-Shoes.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Jumper_Shoes" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Jumper" },
       "order": 301
     },
     {
@@ -13625,7 +13625,7 @@
       "name": "Flower Hair Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/Icon_hair_event_healing_poppy.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/03/Days_of_heeling_poppy_headpiece_v2.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Healing#Healing_Flower_Hair_Accessory" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Healing#Healing_Pack" },
       "order": 10001
     },
     // #endregion
@@ -13636,7 +13636,7 @@
       "name": "Summer Lights Lantern",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/Icon_prop_days_of_summer_lantern.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Lantern_in_use_v2.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lazy_Days#Lantern" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lazy_Days#Lantern_Pack" },
       "order": 2901
     },
     // #endregion
@@ -13702,7 +13702,7 @@
       "name": "Kizuna AI Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Kizuna-AI-Hairstyle-Icon.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Kizuna-AI-Hairstyle.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Kizuna_AI_Hair" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Hair" },
       "order": 401
     },
     {
@@ -13711,7 +13711,7 @@
       "name": "Kizuna AI Bow",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/Kizuna-AI-Hair-Accessory-Icon.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/Kizuna-AI-Hair-accessory.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Kizuna_AI_Bow" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Bow" },
       "order": 11401
     },
     {
@@ -13720,7 +13720,7 @@
       "name": "Kizuna AI Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Kizuna-AI-cape-icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c8/Kizuna-AI-cape-back.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Kizuna_AI_Cape" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Cape" },
       "order": 10601
     },
     // #endregion
@@ -14024,7 +14024,7 @@
       "name": "Journey Mask",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Journey-Pack-Mask-icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/JourneyPack-Mask-Nastymold.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Journey_Pack" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_for_PlayStation#Journey_Pack" },
       "order": 20001
     },
     {
@@ -14033,7 +14033,7 @@
       "name": "Journey Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/Journey-Pack-Cape-Icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/JourneyPack-Cape-back-Nastymold.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Journey_Pack" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_for_PlayStation#Journey_Pack" },
       "order": 10801
     },
     {
@@ -14042,7 +14042,7 @@
       "name": "Journey Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e9/Journey-Pack-Hairstyle-icon-Morybel-0146.png",
       "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1e/JourneyPack-Hair-Nastymold.png",
-      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Journey_Pack" },
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_for_PlayStation#Journey_Pack" },
       "order": 901
     },
     // #endregion

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -605,6 +605,8 @@
       "type": "Instrument",
       "name": "Harp",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/LaughingLightCatcher-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d4/Laughing-Light-Catcher-harp.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laughing_Light_Catcher#Instrument" },
       "order": 101
     },
     {
@@ -934,6 +936,8 @@
       "type": "Instrument",
       "name": "Drum",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/89/BlushingProspector-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Blushing_Prospector-Drum.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Blushing_Prospector#Instrument" },
       "order": 2001
     },
     // Hide'n'Seek Pioneer
@@ -1665,6 +1669,8 @@
       "type": "Instrument",
       "name": "Piano",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/CheerfulSpectator-Piano-Credit-Ed.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/Cheerful-Spectator-Piano.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cheerful_Spectator#Instrument" },
       "order": 1001
     },
     // Bowing Medalist
@@ -1874,6 +1880,8 @@
       "type": "Instrument",
       "name": "Contrabass",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/64/FrightenedRefugee-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Frightened-Refugee-Contrabass-harp.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frightened_Refugee#Instrument" },
       "order": 301
     },
     // Fainting Warrior
@@ -2146,6 +2154,8 @@
       "type": "Held",
       "name": "Fireworks Staff",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/SalutingCaptain-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Instrument_firework_staff_in_hand.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Captain#Prop" },
       "order": 2601
     },
     // Lookout Scout
@@ -2175,6 +2185,8 @@
       "type": "Instrument",
       "name": "Horn",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/82/LookoutScout-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Lookout-Scout-Horn.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lookout_Scout#Instrument" },
       "order": 1401
     },
     {
@@ -2715,6 +2727,8 @@
       "group": "Ultimate",
       "name": "Lightseekers Ultimate Umbrella",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Icon_prop_lightseekers_large_umbrella.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ee/Lightseekers_ultimate_umbrella_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lightseekers_Guide#Ultimate_Gifts" },
       "order": 3101
     },
     // #endregion
@@ -2897,6 +2911,8 @@
       "group": "Ultimate",
       "name": "Sanctuary Ultimate Handpan",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e4/Icon_instrument_sanctuary_hand_pan.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/Sanctuary-Handpan-ultimate.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sanctuary_Guide#Ultimate_Gifts" },
       "order": 2301
     },
     {
@@ -3005,6 +3021,8 @@
       "group": "Ultimate",
       "name": "Prophecy Ultimate Drum",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/Icon_instrument_prophecy_drum.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/48/Prophecy-ultimate-_drum.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophecy_Guide#Ultimate_Gifts" },
       "order": 2501
     },
     {
@@ -3207,6 +3225,8 @@
       "group": "Ultimate",
       "name": "Assembly Ultimate Bugle",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/83/Icon_instrument_assembly_bugle.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Assembly-ultimate-Buggle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Ultimate_Gifts" },
       "order": 1701
     },
     {
@@ -4482,6 +4502,8 @@
       "type": "Held",
       "name": "Camera",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/23/Moments-Guide-Prop-Camera-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Moments-Guide-Prop-Camera.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Moments_Guide#Prop" },
       "order": 4001
     },
     {
@@ -4583,6 +4605,8 @@
       "name": "Moments Ultimate Camera",
       "group": "Ultimate",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4f/Moments-Guide-Prop-Ultimate-Camera-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/Moments-Guide-Prop-Ultimate-Camera.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Moments_Guide#Ultimate_Gifts" },
       "order": 4002
     },
     {
@@ -4821,6 +4845,8 @@
       "type": "Instrument",
       "name": "Small Bell",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/67/Mimi-4117_02_leaping_dancer_instrument.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c9/Gratitude-Leaping-Dancer-Small-Bell.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Leaping_Dancer#Instrument" },
       "order": 2101
     },
     {
@@ -4976,6 +5002,8 @@
       "type": "Instrument",
       "name": "Large Bell",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/Mimi-4117_02_greeting_shaman_instrument.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/18/Gratitude-Greeting-Shaman-Large_bell.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Greeting_Shaman#Instrument" },
       "order": 2201
     },
     {
@@ -5137,6 +5165,8 @@
       "type": "Instrument",
       "name": "Flute",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/01/Mimi-4117_03_doublefive_light_catcher_instrument.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/22/Lightseekers-Doublefive-Light-Catcher-Flute.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Doublefive_Light_Catcher#Instrument" },
       "order": 1501
     },
     {
@@ -5213,6 +5243,8 @@
       "type": "Held",
       "name": "Laidback Pioneer Umbrella",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d5/Mimi-4117_03_laidback_pioneer_item.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Instrument_lightseekers_small_umbrella.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laidback_Pioneer#Prop" },
       "order": 3001
     },
     {
@@ -5286,6 +5318,8 @@
       "type": "Instrument",
       "name": "Panflute",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ea/Mimi-4117_03_twirling_champion_instrument.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Lightseekers-Twirling-Champion_-_Panpipes-Panflute.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Twirling_Champion#Instrument" },
       "order": 1601
     },
     {
@@ -5839,6 +5873,8 @@
       "type": "Instrument",
       "name": "Guitar",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Mimi-4117_04_pleaful_parent_instrument.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e0/Belonging-Pleaful-Parent-Guitar.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleaful_Parent#Instrument" },
       "order": 401
     },
     {
@@ -5951,6 +5987,8 @@
       "type": "Instrument",
       "name": "Ukulele",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Mimi-4117_04_hairtousle_teen_instrument.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/06/Belonging-Hairtousle-teen-Ukulele.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hairtousle_Teen#Instrument" },
       "order": 601
     },
     {
@@ -6411,6 +6449,8 @@
       "type": "Instrument",
       "name": "Winter Piano",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Mimi-4117_05_respectful_pianist_instrument.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Rhythm-Respectul-Pianist-Piano.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Respectful_Pianist#Instrument" },
       "order": 1101
     },
     {
@@ -6496,6 +6536,8 @@
       "type": "Instrument",
       "name": "Xylophone",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Mimi-4117_05_thoughtful_director_instrument.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c4/Rhythm-Thoughtful-Director-xylophone.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Thoughtful_Director#Instrument" },
       "order": 1201
     },
     {
@@ -8123,6 +8165,8 @@
       "type": "Instrument",
       "name": "Lute",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Icon_instrument_dreams_lute.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/61/Dreams-Dancing-Performer-Guitar.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dancing_Performer#Instrument" },
       "order": 701
     },
     {
@@ -9628,6 +9672,8 @@
       "type": "Instrument",
       "name": "Kalimba",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Icon_season_of_flight_instrument_kalimba.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/89/Flight-Tinkering-Chimesmith-Kalimba.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tinkering_Chimesmith#Instrument" },
       "order": 1301
     },
     {
@@ -10373,6 +10419,8 @@
       "type": "Instrument",
       "name": "Electric Guitar",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/Morybel-0146-SoPerformance_-_Mellow_Musician-electrice-guitar-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e7/Performance-Electric-guitar.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mellow_Musician#Instrument" },
       "order": 801
     },
     {
@@ -10680,6 +10728,8 @@
       "type": "Instrument",
       "name": "Dark Horn",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/14/SOShattering-Dark-Horn-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/SOShattering-Dark-Horn-Instrument.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Darkness#Prop" },
       "order": 2751
     },
     {
@@ -11129,6 +11179,8 @@
       "type": "Instrument",
       "name": "Voice of AURORA",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/09/Aurora-Voice-of-Aurora-Icon-Morybel-0146-.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/36/Aurora-Voice-of-Aurora-Instrument.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Voice_of_AURORA" },
       "order": 2801
     },
     {
@@ -11758,6 +11810,8 @@
       "type": "Instrument",
       "name": "Manta Flute",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8e/Passage-Overactive-Overachiever-Instrument-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2f/Passage-Overactive-Overachiever-Instrument.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Overactive_Overachiever#Instrument" },
       "order": 2851
     },
     {
@@ -12245,6 +12299,8 @@
       "type": "Held",
       "name": "Days of Fortune Enchanted Umbrella",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/50/Prosperous-Party-Parasol-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1e/Prosperous-Party-Parasol-prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Enchanted_Umbrella" },
       "order": 3201
     },
     {
@@ -12375,6 +12431,8 @@
       "type": "Held",
       "name": "Days of Love Serendipitous Scepter",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/32/Days-of-Love-Wand-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/Days-of-Love-Scepter.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love#Days_of_Love_Serendipitous_Scepter" },
       "order": 2701
     },
     {
@@ -13455,6 +13513,8 @@
       "type": "Held",
       "name": "Summer Lights Lantern",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/Icon_prop_days_of_summer_lantern.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Lantern_in_use_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lazy_Days#Lantern" },
       "order": 2901
     },
     // #endregion
@@ -13475,6 +13535,8 @@
       "type": "Held",
       "name": "Days of Summer Umbrella",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Icon_prop_summer_umbrella.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Days_of_summer_yellow_umbrella.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lazy_Days#Summer_Parasol" },
       "order": 3301
     },
     {
@@ -13677,6 +13739,8 @@
       "type": "Instrument",
       "name": "Triumph Saxophone",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Triumph-Saxophone-instrument-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/53/Triumph-Saxophone-instrument.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Music#Triumph_Saxophone" },
       "order": 3401
     },
     {
@@ -13699,6 +13763,8 @@
       "type": "Instrument",
       "name": "Triumph Violin",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3c/Triumph-Violon-Instrument-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Triumph-Violon-Instrument.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Music#Triumph_Violin" },
       "order": 3402
     },
     {
@@ -13748,6 +13814,8 @@
       "type": "Instrument",
       "name": "Fledgling Harp",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/SOPerformance-Fledgling-harp-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d1/Performance-Fledgling-harp.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Fledgling_Harp" },
       "order": 201
     },
     {
@@ -13755,6 +13823,8 @@
       "type": "Instrument",
       "name": "Rhythm Guitar",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4c/SOPerformance-Rhythm-Guitar-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/Performance-Rhythm-Guitar-white-guitar.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rhythm_Guitar" },
       "order": 501
     },
     {
@@ -13762,6 +13832,8 @@
       "type": "Instrument",
       "name": "Triumph Handpan",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/SOPerformance-Triumph-Handpan-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/30/Performance-Triumph-Handpan.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Triumph_Handpan" },
       "order": 2401
     },
     {
@@ -13769,6 +13841,8 @@
       "type": "Instrument",
       "name": "Blue Electric Guitar",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/01/Days-of-Sky-2022-instrument-blue-electric-guitar-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/80/Days-of-Sky-2022-instrument-blue-electric-guitar.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#Blue_Electric_Guitar" },
       "order": 901
     },
     // #endregion
@@ -13807,6 +13881,8 @@
       "type": "Instrument",
       "name": "Vessel Flute",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/59/Icon_instrument_vessel_flute.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/41/Vessel-flute-Ocarina-Nintendo-IAP.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Vessel_Flute" },
       "order": 1801
     },
     // #endregion

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -36,6 +36,8 @@
       "type": "Cape",
       "name": "Base Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/30/Icon_cape_brown-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/80/Cape_brown_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Capes#Base_Cape" },
       "unlocked": true,
       "order": 1
     },
@@ -312,6 +314,8 @@
       "type": "Cape",
       "name": "Butterfly Charmer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a7/ButterflyCharmer-2-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/Cape_yellow_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Butterfly_Charmer#Cape" },
       "order": 21
     },
     {
@@ -366,6 +370,8 @@
       "type": "Cape",
       "name": "Butterfly Charmer Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/59/ButterflyCharmer-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/Cape_yellow_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Butterfly_Charmer#Cape" },
       "order": 30
     },
     // Applauding Bellmaker
@@ -1064,6 +1070,8 @@
       "type": "Cape",
       "name": "Pouty Porter Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2e/PoutyPorter-3-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/Cape_teal2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pouty_Porter#Cape" },
       "order": 24
     },
     {
@@ -1077,6 +1085,8 @@
       "type": "Cape",
       "name": "Pouty Porter Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/44/PoutyPorter-4.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/Cape_teal_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pouty_Porter#Cape" },
       "order": 33
     },
     // Dismayed Hunter
@@ -1147,6 +1157,8 @@
       "type": "Cape",
       "name": "Dismayed Hunter Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/DismayedHunter-3-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dc/Cape_purple_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dismayed_Hunter#Cape" },
       "order": 26
     },
     {
@@ -1160,6 +1172,8 @@
       "type": "Cape",
       "name": "Dismayed Hunter Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/67/DismayedHunter-4.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Cape_purple_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dismayed_Hunter#Cape" },
       "order": 35
     },
     // Apologetic Lumberjack
@@ -1453,6 +1467,8 @@
       "type": "Cape",
       "name": "Handstanding Thrillseeker Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c6/HandstandingThrillseeker-2-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ee/Cape_pink_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Handstanding_Thrillseeker#Cape" },
       "order": 27
     },
     {
@@ -1466,6 +1482,8 @@
       "type": "Cape",
       "name": "Handstanding Thrillseeker Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/eb/HandstandingThrillseeker-tier-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e6/Cape_pink_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Handstanding_Thrillseeker#Cape" },
       "order": 36
     },
     // Manta Whisperer
@@ -1734,6 +1752,8 @@
       "type": "Cape",
       "name": "Proud Victor Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/33/ProudVictor-2-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/Cape_red_3.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Proud_Victor#Cape" },
       "order": 22
     },
     {
@@ -1780,6 +1800,8 @@
       "type": "Cape",
       "name": "Proud Victor Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/ProudVictor-4.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/95/Cape_red_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Proud_Victor#Cape" },
       "order": 31
     },
     // #endregion
@@ -1972,6 +1994,8 @@
       "type": "Cape",
       "name": "Courageous Soldier Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/03/CourageousSoldier-3-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/38/Cape_green2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Courageous_Soldier#Cape" },
       "order": 23
     },
     {
@@ -1985,6 +2009,8 @@
       "type": "Cape",
       "name": "Courageous Soldier Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9b/CourageousSoldier-4.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e5/Cape_green_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Courageous_Soldier#Cape" },
       "order": 32
     },
     // Stealthy Survivor
@@ -2033,6 +2059,8 @@
       "type": "Cape",
       "name": "Stealthy Survivor Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6c/StealthySurvivor-3-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9d/Cape_black_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stealthy_Survivor#Cape" },
       "order": 28
     },
     {
@@ -2046,6 +2074,8 @@
       "type": "Cape",
       "name": "Stealthy Survivor Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Icon_cape_black_tier_2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/70/Cape_black_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stealthy_Survivor#Cape" },
       "order": 37
     },
     // Saluting Captain
@@ -2378,6 +2408,8 @@
       "type": "Cape",
       "name": "Memory Whisperer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ec/MemoryWhisperer-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/62/Cape_white_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Memory_Whisperer#Cape" },
       "order": 29
     },
     {
@@ -2391,6 +2423,8 @@
       "type": "Cape",
       "name": "Memory Whisperer Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Icon_cape_white_tier_2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Cape_white_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Memory_Whisperer#Cape" },
       "order": 38
     },
     // Polite Scholar
@@ -2511,6 +2545,8 @@
       "type": "Cape",
       "name": "Praying Acolyte Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/PrayingAcolyte-3-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Cape_blue_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Praying_Acolyte#Cape" },
       "order": 25
     },
     {
@@ -2524,6 +2560,8 @@
       "type": "Cape",
       "name": "Praying Acolyte Cape 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/PrayingAcolyte-4.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/90/Cape_blue_tier_2_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Praying_Acolyte#Cape" },
       "order": 34
     },
     // #endregion
@@ -2867,6 +2905,8 @@
       "group": "Ultimate",
       "name": "Sanctuary Ultimate Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Icon_cape_sanctuary_manta-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5a/Season_of_sanctuary_cape_ultimate_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sanctuary_Guide#Ultimate_Gifts" },
       "order": 1602
     },
     {
@@ -3059,6 +3099,8 @@
       "group": "Ultimate",
       "name": "Dreams Ultimate Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/Icon_cape_dreams_ultimate-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e1/Dreams_cape_ultimate_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dreams_Guide#Ultimate_Gifts" },
       "order": 1804
     },
     {
@@ -3173,6 +3215,8 @@
       "group": "Ultimate",
       "name": "Assembly Ultimate Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bc/Icon_cape_assembly_ultimate-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/Assembly_cape_ultimate_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Ultimate_Gifts" },
       "order": 1901
     },
     {
@@ -3543,6 +3587,8 @@
       "type": "Cape",
       "name": "Abyss Ultimate Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9e/SOAbyss-Ultime-gift-Cape-vector-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/79/SOAbyss-Ultime-gift-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Abyss_Guide#Ultimate_Gifts" },
       "order": 2205
     },
     {
@@ -3655,6 +3701,8 @@
       "type": "Cape",
       "name": "Performance Ultimate Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/SOPerformance-ultimate-cape-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/85/SOPerformance-ultimate-cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Performance_Guide#Ultimate_Gifts" },
       "order": 2301
     },
     {
@@ -3807,6 +3855,8 @@
       "type": "Cape",
       "name": "Shattering Ultimate Manta Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/SOShattering-ultimate-Cape-manta-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/SOShattering-ultimate-Cape-manta-bac.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Void_of_Shattering#Cape" },
       "order": 2405
     },
     {
@@ -3814,6 +3864,8 @@
       "type": "Cape",
       "name": "Shattering Ultimate Krill Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/98/SOShattering-ultimate-Cape-krill-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/SOShattering-ultimate-Cape-krill-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Void_of_Shattering#Cape" },
       "order": 2402
     },
     {
@@ -3935,6 +3987,8 @@
       "type": "Cape",
       "name": "AURORA Ultimate Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/SoAurora-Ultimate-Cape-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fb/SoAurora-Ultimate-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Ultimate_Gifts" },
       "order": 2506
     },
     {
@@ -4417,6 +4471,8 @@
       "type": "Cape",
       "name": "Passage Ultimate Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3a/Passage-Ultimate-Guide-Cape-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/13/Passage-Ultimate-Guide-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Passage_Guide#Ultimate_Gifts" },
       "order": 2703
     },
     // #endregion
@@ -4649,6 +4705,8 @@
       "type": "Cape",
       "name": "Stretching Guru Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3f/Icon_cape_gratitude_red-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Cape1-Season_of_Gratitude_2019.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Guru#Cape" },
       "order": 1102
     },
     {
@@ -4860,6 +4918,8 @@
       "type": "Cape",
       "name": "Saluting Protector Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7c/Icon_cape_gratitude_white-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Gratitude_cape_white_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Protector#Cape" },
       "order": 1101
     },
     {
@@ -5011,6 +5071,8 @@
       "type": "Cape",
       "name": "Piggyback Lightseeker Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ec/Icon_cape_lightseekers_blue_blue-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/Lightseekers_cape_isle_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Piggyback_Lightseeker#Cape" },
       "order": 1202
     },
     {
@@ -5306,6 +5368,8 @@
       "type": "Cape",
       "name": "Crab Whisperer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Icon_cape_lightseekers_petal-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/Lightseekers_cape_wasteland_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Whisperer#Cape" },
       "order": 1201
     },
     {
@@ -5383,6 +5447,8 @@
       "type": "Cape",
       "name": "Shushing Light Scholar Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Icon_cape_lightseekers_blue_gold-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Lightseekers_cape_vault_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shushing_Light_Scholar#Cape" },
       "order": 1203
     },
     {
@@ -5446,6 +5512,8 @@
       "type": "Cape",
       "name": "Confetti Cousin Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/Icon_cape_belonging_red-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/Belonging_cape_red_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confetti_Cousin#Cape" },
       "order": 1301
     },
     {
@@ -5715,6 +5783,8 @@
       "type": "Cape",
       "name": "Wise Grandparent Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9e/Icon_cape_belonging_white-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/Belonging_cape_white_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wise_Grandparent#Cape" },
       "order": 1303
     },
     {
@@ -5799,6 +5869,8 @@
       "type": "Cape",
       "name": "Pleaful Parent Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fb/Icon_cape_belonging_blue-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/44/Belonging_cape_dark_blue_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleaful_Parent#Cape" },
       "order": 1302
     },
     {
@@ -6239,6 +6311,8 @@
       "type": "Cape",
       "name": "Troupe Juggler Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Icon_cape_rhythm_purple-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Season_of_rhythm_cape_valley_juggle_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Juggler#Cape" },
       "order": 1001
     },
     {
@@ -6441,6 +6515,8 @@
       "type": "Cape",
       "name": "Thoughtful Director Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fb/Icon_cape_rhythm_blue-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/Season_of_rhythm_cape_vault_think_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Thoughtful_Director#Cape" },
       "order": 1002
     },
     {
@@ -6612,6 +6688,8 @@
       "type": "Cape",
       "name": "Indifferent Alchemist Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/Icon_cape_enchangment_purple_fold-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/Season_of_enchantment_cape_indifferent_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Indifferent_Alchemist#Cape" },
       "order": 1503
     },
     {
@@ -6688,6 +6766,8 @@
       "type": "Cape",
       "name": "Crab Walker Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2d/Icon_cape_enchantment_purple-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Season_of_enchantment_cape_crab_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Walker#Cape" },
       "order": 1501
     },
     {
@@ -6836,6 +6916,8 @@
       "type": "Cape",
       "name": "Snoozing Carpenter Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/Icon_cape_enchantment_orange-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Season_of_enchantment_cape_sleepy_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Snoozing_Carpenter#Cape" },
       "order": 1502
     },
     {
@@ -6925,6 +7007,8 @@
       "type": "Cape",
       "name": "Playfighting Herbalist Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/99/Icon_cape_enchantment_orange_fold-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/99/Icon_cape_enchantment_orange_fold-Morybel-0146.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Cape" },
       "order": 1504
     },
     {
@@ -7083,6 +7167,8 @@
       "type": "Cape",
       "name": "Timid Bookworm Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/96/Icon_cape_sanctuary_butterfly-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Season_of_sanctuary_cape_timid_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Timid_Bookworm#Cape" },
       "order": 1601
     },
     {
@@ -7324,6 +7410,8 @@
       "type": "Cape",
       "name": "Grateful Shell Collector Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Icon_cape_sanctuary_shell-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/86/Season_of_sanctuary_cape_grateful_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Grateful_Shell_Collector#Cape" },
       "order": 1603
     },
     {
@@ -7422,6 +7510,8 @@
       "type": "Cape",
       "name": "Chill Sunbather Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/Icon_cape_sanctuary_flower-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3a/Season_of_sanctuary_cape_chill_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chill_Sunbather#Cape" },
       "order": 1604
     },
     {
@@ -7513,6 +7603,8 @@
       "type": "Cape",
       "name": "Prophet of Water Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Icon_cape_prophecy_blue-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b5/Prophecy_cape_water_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Water#Cape" },
       "order": 1702
     },
     {
@@ -7618,6 +7710,8 @@
       "type": "Cape",
       "name": "Prophet of Earth Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/71/Icon_cape_prophecy_maroon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/80/Prophecy_cape_earth_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Earth#Cape" },
       "order": 1703
     },
     {
@@ -7725,6 +7819,8 @@
       "type": "Cape",
       "name": "Prophet of Air Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/76/Icon_cape_prophecy_purple-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/Prophecy_cape_air_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Air#Cape" },
       "order": 1701
     },
     {
@@ -8018,6 +8114,8 @@
       "type": "Cape",
       "name": "Dancing Performer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6b/Icon_cape_dreams_dancing-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/Dreams_cape_dancing_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dancing_Performer#Cape" },
       "order": 1802
     },
     {
@@ -8096,6 +8194,8 @@
       "type": "Cape",
       "name": "Peeking Postman Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/Icon_cape_dreams_peeking-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d5/Dreams_cape_peeking_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Peeking_Postman#Cape" },
       "order": 1801
     },
     {
@@ -8196,6 +8296,8 @@
       "type": "Cape",
       "name": "Spinning Mentor Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/Icon_cape_dreams_spinning-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4f/Dreams_cape_spinning_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Spinning_Mentor#Cape" },
       "order": 1803
     },
     {
@@ -8380,6 +8482,8 @@
       "type": "Cape",
       "name": "Scolding Student Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Icon_cape_assembly_green-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/Assembly_cape_scolding_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scolding_Student#Cape" },
       "order": 1902
     },
     {
@@ -8997,6 +9101,8 @@
       "type": "Cape",
       "name": "Stretching Lamplighter Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/61/Icon_cape_littleprince_3-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/Season_of_little_prince_cape_lamplighter_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Lamplighter#Cape" },
       "order": 2003
     },
     {
@@ -9075,6 +9181,8 @@
       "type": "Cape",
       "name": "Slouching Soldier Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/59/Icon_cape_littleprince_tattered-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/Season_of_little_prince_cape_slouching_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slouching_Soldier#Cape" },
       "order": 2002
     },
     {
@@ -9158,6 +9266,8 @@
       "type": "Cape",
       "name": "Sneezing Geographer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b8/Icon_cape_littleprince4-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/Season_of_little_prince_cape_geographer_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sneezing_Geographer#Cape" },
       "order": 2004
     },
     {
@@ -9235,6 +9345,8 @@
       "type": "Cape",
       "name": "Star Collector Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/68/Icon_cape_littleprince_1-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Season_of_little_prince_cape_star_collector_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Star_Collector#Cape" },
       "order": 2001
     },
     {
@@ -9275,6 +9387,8 @@
       "type": "Cape",
       "name": "Little Prince Scarf Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/Icon_cape_littleprince_scarf-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Season_of_little_prince_cape7_iap_scarf.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_The_Little_Prince#Little_Prince_Scarf_Cape" },
       "order": 2005
     },
     {
@@ -9282,6 +9396,8 @@
       "type": "Cape",
       "name": "Little Prince Asteroid Jacket",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0a/Icon_cape_littleprince_asteroid-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/22/Little_prince_asteroid_cape_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_The_Little_Prince#Little_Prince_Asteroid_Jacket" },
       "order": 2006
     },
     {
@@ -9365,6 +9481,8 @@
       "type": "Cape",
       "name": "Lively Navigator Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/Season_of_flight_icon_cape_lively_navigator-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Season_of_flight_cape_lively_navigator_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lively_Navigator#Cape" },
       "order": 2102
     },
     {
@@ -9442,6 +9560,8 @@
       "type": "Cape",
       "name": "Light Whisperer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Season_of_flight_icon_cape_light_whisperer-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Season_of_flight_cape_light_whisperer_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Light_Whisperer#Cape" },
       "order": 2101
     },
     {
@@ -9699,6 +9819,8 @@
       "type": "Cape",
       "name": "Anxious Angler Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/SOAbyss-Anxious-Angler-cape-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/SOAbyss-Anxious-Angler-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Anxious_Angler#Cape" },
       "order": 2203
     },
     {
@@ -9787,6 +9909,8 @@
       "type": "Cape",
       "name": "Ceasing Commodore Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/SOAbyss-Ceasing-Commodore-cape-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/71/SOAbyss-Ceasing-Commodore-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ceasing_Commodore#Cape" },
       "order": 2201
     },
     {
@@ -9870,6 +9994,8 @@
       "type": "Cape",
       "name": "Bumbling Boatswain Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/SOAbyss-Bumbling-Boatswain-Cape-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/45/SOAbyss-Bumbling-Boatswain-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bumbling_Boatswain#Cape" },
       "order": 2204
     },
     {
@@ -9956,6 +10082,8 @@
       "type": "Cape",
       "name": "Cackling Cannoneer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3d/SOAbyss-Cackling-Cannoneer-Cape-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/50/SOAbyss-Cackling-Cannoneer-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cackling_Cannoneer#Cape" },
       "order": 2202
     },
     {
@@ -10158,6 +10286,8 @@
       "type": "Cape",
       "name": "Forgetful Storyteller Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/SOPerformance_-Forgetful_Storyteller_-_Cape_-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/SOPerformance_-Forgetful_Storyteller_-_Cape_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forgetful_Storyteller#Cape" },
       "order": 2302
     },
     {
@@ -10214,6 +10344,8 @@
       "type": "Cape",
       "name": "Mellow Musician Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/16/Morybel-0146-SoPerformance_-_Mellow_Musician-cape-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/SoPerformance_-_Mellow_Musician-cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mellow_Musician#Cape" },
       "order": 2303
     },
     {
@@ -10375,6 +10507,8 @@
       "type": "Cape",
       "name": "Jellyfish Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/SOShattering-Light-Cape-Jellyfish-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bc/SOShattering-Light-Cape-Jellyfish-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Light#Cape" },
       "order": 2404
     },
     {
@@ -10423,6 +10557,8 @@
       "type": "Cape",
       "name": "Manta Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fb/SOShattering-Light-Cape-manta-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/SOShattering-Light-Cape-manta-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Light#Cape" },
       "order": 2403
     },
     {
@@ -10507,6 +10643,8 @@
       "type": "Cape",
       "name": "Darkness Plant Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/SOShattering-Dark-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/08/SOShattering-Dark-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Darkness#Cape" },
       "order": 2401
     },
     {
@@ -10645,6 +10783,8 @@
       "type": "Cape",
       "name": "Running Wayfarer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/be/SoAurora-Running-Wayfarer-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/66/SoAurora-Running-Wayfarer-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Running_Wayfarer#Cape" },
       "order": 2502
     },
     {
@@ -10740,6 +10880,8 @@
       "type": "Cape",
       "name": "Mindful Miner Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/66/SoAurora-Mindful-Miner-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d2/SoAurora-Mindful-Miner-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mindful_Miner#Cape" },
       "order": 2504
     },
     {
@@ -10839,6 +10981,8 @@
       "type": "Cape",
       "name": "Warrior of Love Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a9/SoAurora-Warrior-of-Love-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/19/SoAurora-Warrior-of-Love-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Warrior_of_Love#Cape" },
       "order": 2503
     },
     {
@@ -10932,6 +11076,8 @@
       "type": "Cape",
       "name": "Seed of Hope Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/SoAurora-Seed-of-Hope-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/SoAurora-Seed-of-Hope-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Seed_of_Hope#Cape" },
       "order": 2501
     },
     {
@@ -10990,6 +11136,8 @@
       "type": "Cape",
       "name": "Giving In Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b1/SoAurora-Giving-In-Cape-IAP-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/SoAurora-Giving-In-Cape-IAP-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Concert#Giving_In_Cape" },
       "order": 2507
     },
     {
@@ -10997,6 +11145,8 @@
       "type": "Cape",
       "name": "Wings of AURORA",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/SoAURORA-Wings-of-AURORA-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/SoAURORA-Wings-of-AURORA-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Concert#Wings_of_AURORA" },
       "order": 2505
     },
     {
@@ -11090,6 +11240,8 @@
       "type": "Cape",
       "name": "Bereft Veteran Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e6/SoRemembrance-Bereft-Veteran-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/SoRemembrance-Bereft-Veteran-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bereft_Veteran#Cape" },
       "order": 2601
     },
     {
@@ -11259,6 +11411,8 @@
       "type": "Cape",
       "name": "Tiptoeing Tea-Brewer Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/SoRemembrance-Tiptoeing-Tea-Brewer-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/SoRemembrance-Tiptoeing-Tea-Brewer-Cape-Back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tiptoeing_Tea-Brewer#Cape" },
       "order": 2603
     },
     {
@@ -11322,6 +11476,8 @@
       "type": "Cape",
       "name": "Wounded Warrior Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/SoRemembrance-Wounded-Warrior-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/SoRemembrance-Wounded-Warrior-Cape-Back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wounded_Warrior#Cape" },
       "order": 2602
     },
     {
@@ -11469,6 +11625,8 @@
       "type": "Cape",
       "name": "Tumbling Troublemaker Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/Passage-Tumbling-Troublemaker-Cape-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c0/Passage-Tumbling-Troublemaker-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Cape" },
       "order": 2701
     },
     {
@@ -11621,6 +11779,8 @@
       "type": "Cape",
       "name": "Overactive Overachiever Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f3/Passage-Overactive-Overachiever-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9a/Passage-Overactive-Overachiever-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Overactive_Overachiever#Cape" },
       "order": 2702
     },
     {
@@ -11708,6 +11868,8 @@
       "type": "Cape",
       "name": "Reassuring Ranger Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/Reassuring-Ranger-Cape-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/20/Reassuring-Ranger-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Reassuring_Ranger#Cape" },
       "order": 2801
     },
     {
@@ -12011,6 +12173,8 @@
       "type": "Cape",
       "name": "Days of Fortune Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/01/Icon_cape_fortune-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Chinese_new_year_cape_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Cape" },
       "order": 10001
     },
     {
@@ -12054,6 +12218,8 @@
       "type": "Cape",
       "name": "Days of Fortune Fish Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/41/Days_of_Fortune_-_Fish_cape_icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1f/Days-of-fortune-2021-outfit-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Fish_Cape" },
       "order": 10002
     },
     {
@@ -12275,6 +12441,8 @@
       "type": "Cape",
       "name": "Pink Bloom Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/Icon_cape_bloom-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Blossom_cape_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Bloom_Cape" },
       "order": 10101
     },
     {
@@ -12310,6 +12478,8 @@
       "type": "Cape",
       "name": "Purple Bloom Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9a/Purple_Bloom_Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a1/Wisteria-cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Purple_Bloom_Cape" },
       "order": 10103
     },
     {
@@ -12336,6 +12506,8 @@
       "type": "Cape",
       "name": "Red Bloom Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Days-of-Bloom-Tulip-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/Days-of-Bloom-Tulip-Cape-back-1.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Red_Bloom_Cape" },
       "order": 10102
     },
     {
@@ -12374,6 +12546,8 @@
       "type": "Cape",
       "name": "Earth Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/62/Icon_cape_earth.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/51/Earth_cape_2020_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Earth_Cape" },
       "order": 10201
     },
     {
@@ -12390,6 +12564,8 @@
       "type": "Cape",
       "name": "Ocean Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Icon_cape_ocean-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2f/Ocean_cape_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Ocean_Cape" },
       "order": 10202
     },
     {
@@ -12397,6 +12573,8 @@
       "type": "Cape",
       "name": "Nature Turtle Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/Days-of-Nature-2022-turtle-cape-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7c/Days-of-Nature-2022-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Nature_Turtle_Cape" },
       "order": 10203
     },
     {
@@ -12434,6 +12612,8 @@
       "type": "Cape",
       "name": "Nature School Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Days-of-Nature-Fish-Vortex-cape-icon-Ray.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/22/Days-of-Nature-Fish-Vortex-cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Nature_School_Cape" },
       "order": 10204
     },
     {
@@ -12468,6 +12648,8 @@
       "type": "Cape",
       "name": "Rainbow Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/Icon_cape_rainbow-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/Rainbow_cape_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Rainbow_Cape" },
       "order": 10302
     },
     {
@@ -12643,6 +12825,8 @@
       "type": "Cape",
       "name": "Dark Rainbow Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/Days-of-Color-Dark-Rainbow-Cape-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ac/Days-of-Color-Dark-Rainbow-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Dark_Rainbow_Cape" },
       "order": 10301
     },
     // #endregion
@@ -12911,6 +13095,8 @@
       "type": "Cape",
       "name": "Spooky Bat Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5a/Icon_cape_bat-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ab/Bat_cape_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Spooky_Bat_Cape" },
       "order": 10401
     },
     {
@@ -12936,6 +13122,8 @@
       "type": "Cape",
       "name": "Mischief Web Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/Icon_cape_spider-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/82/Spider_cape_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Web_Cape" },
       "order": 10402
     },
     {
@@ -12968,6 +13156,8 @@
       "type": "Cape",
       "name": "Mischief Withered Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Icon_2021_mischief_leaf_cape-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Cape_2021_mischief_leaf_cape.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Withered_Cape" },
       "order": 10403
     },
     {
@@ -13045,6 +13235,8 @@
       "type": "Cape",
       "name": "Cat Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e2/Days-of-Mischief-Cat-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9d/Days-of-Mischief-2022-Cat-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Cat_Cape" },
       "order": 10404
     },
     {
@@ -13079,6 +13271,8 @@
       "type": "Cape",
       "name": "Snowflake Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/80/Icon_cape_snowflake-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/29/Snowflake_cape.back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Snowflake_Cape" },
       "order": 10503
     },
     {
@@ -13086,6 +13280,8 @@
       "type": "Cape",
       "name": "Days of Feast Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/04/Icon_cape_santa-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4d/Santa_cape_back_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Days_of_Feast_Cape" },
       "order": 10501
     },
     {
@@ -13198,6 +13394,8 @@
       "type": "Cape",
       "name": "Winter Ancestor Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/36/Days_of_Feast_Elder_Cape_icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/Feast_Elder_Cape_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Winter_Ancestor_Cape" },
       "order": 10502
     },
     {
@@ -13234,6 +13432,8 @@
       "type": "Cape",
       "name": "Cozy Hermit Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/ce/Days-of-Feast-Yeti-Fur-Cape-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Days-of-Feast-Yeti-Fur-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Cozy_Hermit_Cape" },
       "order": 10504
     },
     // #endregion
@@ -13333,6 +13533,8 @@
       "type": "Cape",
       "name": "Kizuna AI Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Kizuna-AI-cape-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c8/Kizuna-AI-cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Kizuna_AI_Cape" },
       "order": 10601
     },
     // #endregion
@@ -13372,19 +13574,28 @@
       "guid": "QjK8cvBTfX",
       "type": "Cape",
       "name": "Sunlight Pink Towel Cape",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/Sunlight-Pink-Towel-Cape-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/Sunlight-Pink-Towel-Cape-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/82/Sunlight-Pink-Towel-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Pink_Beach_Towel_Cape" },
+      "order": 10352
     },
     {
       "guid": "FaGQYktG04",
       "type": "Cape",
       "name": "Sunlight Orange Towel Cape",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/Sunlight-Orange-Towel-Cape-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/Sunlight-Orange-Towel-Cape-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ec/Sunlight-Orange-Towel-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Yellow_Beach_Towel_Cape" },
+      "order": 10353
     },
     {
       "guid": "NBkEtlvG6-",
       "type": "Cape",
       "name": "Sunlight Blue Towel Cape",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8f/Sunlight-Blue-Towel-Cape-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8f/Sunlight-Blue-Towel-Cape-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/Sunlight-Blue-Towel-Cape-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Blue_Beach_Towel_Cape" },
+      "order": 10351
     },
     {
       "guid": "03n8xOK3J3",
@@ -13510,6 +13721,8 @@
       "type": "Cape",
       "name": "Orange Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/18/Icon_cape_orange-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8e/Cape_orange_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Starter_Pack" },
       "order": 4
     },
     {
@@ -13517,6 +13730,8 @@
       "type": "Cape",
       "name": "Founder's Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c9/Icon_cape_tgc_b-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Founders_cape_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Founder%27s_Pack" },
       "order": 3
     },
     {
@@ -13524,6 +13739,8 @@
       "type": "Cape",
       "name": "Beta Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2e/Beta-cape-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/Beta_cape_back_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Beta_Cape" },
       "order": 2
     },
     {
@@ -13563,6 +13780,8 @@
       "type": "Cape",
       "name": "Nintendo Blue Switch Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dd/Icon_cape_nintendo_blue-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/Cape_nintendo_blue_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nintendo_Pack" },
       "order": 10702
     },
     {
@@ -13570,6 +13789,8 @@
       "type": "Cape",
       "name": "Nintendo Red Switch Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/98/Icon_cape_nintendo_red-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/90/Cape_nintendo_red_back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nintendo_Pack" },
       "order": 10701
     },
     {
@@ -13604,6 +13825,8 @@
       "type": "Cape",
       "name": "Journey Cape",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/Journey-Pack-Cape-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/JourneyPack-Cape-back-Nastymold.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Journey_Pack" },
       "order": 10801
     },
     {

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -26,6 +26,8 @@
       "type": "Hair",
       "name": "Base Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/Icon_hair_default.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/39/Hair02-Default.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hair#Base_Hairstyle" },
       "unlocked": true,
       "order": 1
     },
@@ -86,6 +88,8 @@
       "type": "Hair",
       "name": "Pointing Candlemaker Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/PointingCandlemaker-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/Hair18-Short_Cowlick.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pointing_Candlemaker#Hair" },
       "order": 2
     },
     {
@@ -156,6 +160,8 @@
       "type": "Hair",
       "name": "Ushering Stargazer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/UsheringStargazer-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/Hair06-Single_Ponytail.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ushering_Stargazer#Hair" },
       "order": 3
     },
     {
@@ -232,6 +238,8 @@
       "type": "Hair",
       "name": "Rejecting Voyager Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3f/RejectingVoyager-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e6/Hair34-One_Side_Short.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rejecting_Voyager#Hair" },
       "order": 4
     },
     {
@@ -387,6 +395,8 @@
       "type": "Hair",
       "name": "Applauding Bellmaker Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f2/ApplaudingBellmaker-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/Hair05-Pippi_Ponytails.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Applauding_Bellmaker#Hair" },
       "order": 7
     },
     {
@@ -448,6 +458,8 @@
       "type": "Hair",
       "name": "Waving Bellmaker Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/WavingBellmaker-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Hair10-Small_Tuft.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Waving_Bellmaker#Hair" },
       "order": 5
     },
     {
@@ -524,6 +536,8 @@
       "type": "Hair",
       "name": "Slumbering Shipwright Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2f/SlumberingShipwright-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a3/Hair37-Mid_Mohawk.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slumbering_Shipwright#Hair" },
       "order": 6
     },
     {
@@ -618,6 +632,8 @@
       "type": "Hair",
       "name": "Laughing Light Catcher Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/LaughingLightCatcher-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/Hair26-Puffy_Ponytails.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laughing_Light_Catcher#Hair" },
       "order": 22
     },
     {
@@ -670,6 +686,8 @@
       "type": "Hair",
       "name": "Bird Whisperer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/BirdWhisperer-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/48/Hair11-Vertical_Ponytail.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bird_Whisperer#Hair" },
       "order": 23
     },
     // Exhausted Dock Worker
@@ -838,6 +856,8 @@
       "type": "Hair",
       "name": "Shivering Trailblazer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/ShiveringTrailblazer-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/18/Hair08-Wispy.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shivering_Trailblazer#Hair" },
       "order": 24
     },
     // Blushing Prospector
@@ -867,6 +887,8 @@
       "type": "Hair",
       "name": "Blushing Prospector Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c5/BlushingProspector-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b1/Hair32-Pigtail_Braids.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Blushing_Prospector#Hair" },
       "order": 12
     },
     {
@@ -922,6 +944,8 @@
       "type": "Hair",
       "name": "Hide'n'Seek Pioneer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/20/HideNSeekPioneer-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/Hair14-Bob.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hide%27n%27Seek_Pioneer#Hair" },
       "order": 10
     },
     {
@@ -999,6 +1023,8 @@
       "type": "Hair",
       "name": "Pouty Porter Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/80/PoutyPorter-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e7/Hair35-One_Side_Medium.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pouty_Porter#Hair" },
       "order": 11
     },
     {
@@ -1080,6 +1106,8 @@
       "type": "Hair",
       "name": "Dismayed Hunter Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8a/DismayedHunter-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c4/Hair17-Thick_Ponytails.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dismayed_Hunter#Hair" },
       "order": 25
     },
     {
@@ -1161,6 +1189,8 @@
       "type": "Hair",
       "name": "Apologetic Lumberjack Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/80/ApologeticLumberjack-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/Hair07-Short_Ponytails.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Apologetic_Lumberjack#Hair" },
       "order": 9
     },
     {
@@ -1231,6 +1261,8 @@
       "type": "Hair",
       "name": "Tearful Light Miner Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/60/TearfulLightMiner-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ec/Hair38-Short_Mullet.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tearful_Light_Miner#Hair" },
       "order": 8
     },
     {
@@ -1325,6 +1357,8 @@
       "type": "Hair",
       "name": "Confident Sightseer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/ConfidentSightseer-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Hair03-Wedge_Cut.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confident_Sightseer#Hair" },
       "order": 13
     },
     {
@@ -1500,6 +1534,8 @@
       "type": "Hair",
       "name": "Backflipping Champion Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/BackflippingChampion-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dc/Hair12-Chris_Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Backflipping_Champion#Hair" },
       "order": 27
     },
     {
@@ -1570,6 +1606,8 @@
       "type": "Hair",
       "name": "Cheerful Spectator Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2f/CheerfulSpectator-Hair-Credit-Ed.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e5/Hair28-Afro.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cheerful_Spectator#Hair" },
       "order": 28
     },
     {
@@ -1638,6 +1676,8 @@
       "type": "Hair",
       "name": "Bowing Medalist Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/BowingMedalist-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/76/Hair04-Lions_Mane_Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bowing_Medalist#Hair" },
       "order": 26
     },
     {
@@ -1771,6 +1811,8 @@
       "type": "Hair",
       "name": "Frightened Refugee Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fc/FrightenedRefugee-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/Hair27-Puffy_Ponytail.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frightened_Refugee#Hair" },
       "order": 14
     },
     {
@@ -1839,6 +1881,8 @@
       "type": "Hair",
       "name": "Fainting Warrior Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5c/FaintingWarrior-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3a/Hair36-One_Side_Long.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Fainting_Warrior#Hair" },
       "order": 16
     },
     {
@@ -1895,6 +1939,8 @@
       "type": "Hair",
       "name": "Courageous Soldier Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/CourageousSoldier-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/Hair13-Short_Mohawk.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Courageous_Soldier#Hair" },
       "order": 15
     },
     {
@@ -1954,6 +2000,8 @@
       "type": "Hair",
       "name": "Stealthy Survivor Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/64/StealthySurvivor-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8e/Hair33-Short_Dreads.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stealthy_Survivor#Hair" },
       "order": 17
     },
     {
@@ -2027,6 +2075,8 @@
       "type": "Hair",
       "name": "Saluting Captain Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/SalutingCaptain-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Hair15-Short_Boy.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Saluting_Captain#Hair" },
       "order": 18
     },
     {
@@ -2167,6 +2217,8 @@
       "type": "Hair",
       "name": "Levitating Adept Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/86/LevitatingAdept-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/27/Hair39-Long_Mullet.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Levitating_Adept#Hair" },
       "order": 19
     },
     {
@@ -2237,6 +2289,8 @@
       "type": "Hair",
       "name": "Meditating Monastic Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/08/Meditating-Monastic-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f5/Hair16-Short_Beard.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Meditating_Monastic#Hair" },
       "order": 20
     },
     {
@@ -2385,6 +2439,8 @@
       "type": "Hair",
       "name": "Polite Scholar Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/PoliteScholar-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Hair01-Bald.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Polite_Scholar#Hair" },
       "order": 99999
     },
     // Praying Acolyte
@@ -2414,6 +2470,8 @@
       "type": "Hair",
       "name": "Praying Acolyte Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3d/PrayingAcolyte-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a2/Hair09-Long_One_Braid.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Praying_Acolyte#Hair" },
       "order": 21
     },
     {
@@ -2478,6 +2536,8 @@
       "group": "Elder",
       "name": "Isle Elder Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/Icon_hair_elder_isle.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/70/Hair19-Isle_Elder.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Isle_Elder#Hair" },
       "order": 51
     },
     {
@@ -2497,6 +2557,8 @@
       "group": "Elder",
       "name": "Prairie Elder Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/Icon_hair_elder_prairie.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/Hair20-Prairie_Elder.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prairie_Elder#Hair" },
       "order": 52
     },
     {
@@ -2516,6 +2578,8 @@
       "group": "Elder",
       "name": "Forest Elder Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e5/Icon_hair_elder_forest.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c6/Hair21-Forest_Elder.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forest_Elder#Hair" },
       "order": 53
     },
     {
@@ -2535,6 +2599,8 @@
       "group": "Elder",
       "name": "Valley Elder Hair 1",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/07/Icon_hair_elder_valley_2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/Hair23-Valley_Elder_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Valley_Elders#Hair" },
       "order": 54
     },
     {
@@ -2543,6 +2609,8 @@
       "group": "Elder",
       "name": "Valley Elder Hair 2",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/Icon_hair_elder_valley_1.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/01/Hair22-Valley_Elder_1.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Valley_Elders#Hair" },
       "order": 55
     },
     // Wasteland Elder
@@ -2552,6 +2620,8 @@
       "group": "Elder",
       "name": "Wasteland Elder Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/Icon_hair_elder_wasteland.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/Hair24-Wasteland_Elder.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wasteland_Elder#Hair" },
       "order": 56
     },
     // Vault Elder
@@ -2561,6 +2631,8 @@
       "group": "Elder",
       "name": "Vault Elder Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/Icon_hair_elder_vault.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Hair25-Vault_Elder.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Vault_Elder#Hair" },
       "order": 57
     },
     // #endregion
@@ -2655,6 +2727,8 @@
       "group": "Ultimate",
       "name": "Rhythm Ultimate Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8a/Icon_hair_rhythm_ultimate.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f3/Season_of_rhythm_hair_ultimate_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rhythm_Guide#Ultimate_Gifts" },
       "order": 1404
     },
     // #endregion
@@ -2685,6 +2759,8 @@
       "group": "Ultimate",
       "name": "Enchantment Ultimate Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/Icon_hair_enchantment_ultimate.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Season_of_enchantment_hair_ultimate_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Enchantment_Guide#Ultimate_Gifts" },
       "order": 1507
     },
     {
@@ -3079,6 +3155,8 @@
       "group": "Ultimate",
       "name": "Assembly Ultimate Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Icon_hair_assembly_ultimate.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d4/Assembly_hair_ultimate_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Ultimate_Gifts" },
       "order": 1901
     },
     {
@@ -3222,6 +3300,8 @@
       "group": "Ultimate",
       "name": "Little Prince Ultimate Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/Icon_hair_prince_ultimate.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7c/Season_of_little_prince_hair6_ultimate.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Rose#Ultimate_Gifts" },
       "order": 2006
     },
     {
@@ -3580,6 +3660,8 @@
       "type": "Hair",
       "name": "Performance Ultimate Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fe/SOPerformance-ultimate-hair-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b5/SOPerformance-ultimate-hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Performance_Guide#Ultimate_Gifts" },
       "order": 2301
     },
     {
@@ -3833,6 +3915,8 @@
       "type": "Hair",
       "name": "AURORA Ultimate Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e2/SoAurora-Ultimate-Hair-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/SoAurora-Ultimate-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Ultimate_Gifts" },
       "order": 2506
     },
     {
@@ -4468,6 +4552,8 @@
       "type": "Hair",
       "name": "Sassy Drifter Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/Mimi-4117_02_sassy_drifter_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/Hair40-SeasonOfGratitude_2019.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sassy_Drifter#Hair" },
       "order": 1101
     },
     {
@@ -4524,6 +4610,8 @@
       "type": "Hair",
       "name": "Stretching Guru Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/32/Mimi-4117_02_stretching_guru_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/43/SoG2-2019_Hat.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Guru#Hair" },
       "order": 1103
     },
     {
@@ -4619,6 +4707,8 @@
       "type": "Hair",
       "name": "Provoking Performer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/59/Mimi-4117_02_provoking_performer_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Hair41-SeasonOfGratitude_2019.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Provoking_Performer#Hair" },
       "order": 1102
     },
     {
@@ -4908,6 +4998,8 @@
       "type": "Hair",
       "name": "Piggyback Lightseeker Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e8/Mimi-4117_03_piggyback_lightseeker_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/Lightseekers_hair_isle_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Piggyback_Lightseeker#Hair" },
       "order": 1203
     },
     {
@@ -4948,6 +5040,8 @@
       "type": "Hair",
       "name": "Doublefive Light Catcher Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Mimi-4117_03_doublefive_light_catcher_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/Lightseekers_hair_prairie_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Doublefive_Light_Catcher#Hair" },
       "order": 1205
     },
     {
@@ -5032,6 +5126,8 @@
       "type": "Hair",
       "name": "Laidback Pioneer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Mimi-4117_03_laidback_pioneer_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Lightseekers_hair_forest_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laidback_Pioneer#Hair" },
       "order": 1204
     },
     {
@@ -5115,6 +5211,8 @@
       "type": "Hair",
       "name": "Twirling Champion Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/04/Mimi-4117_03_twirling_champion_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6d/Lightseekers_hair_valley_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Twirling_Champion#Hair" },
       "order": 1202
     },
     {
@@ -5195,6 +5293,8 @@
       "type": "Hair",
       "name": "Crab Whisperer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/38/Mimi-4117_03_crab_whisperer_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/Lightseekers_hair_wasteland_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Whisperer#Hair" },
       "order": 1201
     },
     {
@@ -5349,6 +5449,8 @@
       "type": "Hair",
       "name": "Confetti Cousin Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Mimi-4117_04_confetti_cousin_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d5/Belonging_Hair_Prairie.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confetti_Cousin#Hair" },
       "order": 1301
     },
     {
@@ -5509,6 +5611,8 @@
       "type": "Hair",
       "name": "Sparkler Parent Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/Mimi-4117_04_sparkler_parent_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b8/Belonging_Hair_Valley.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sparkler_Parent#Hair" },
       "order": 1302
     },
     {
@@ -5939,6 +6043,8 @@
       "type": "Hair",
       "name": "Festival Spin Dancer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/52/Mimi-4117_05_festive_spin_dancer_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Season_of_rhythm_hair_prairie_dance_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Festival_Spin_Dancer#Hair" },
       "order": 1401
     },
     {
@@ -6094,6 +6200,8 @@
       "type": "Hair",
       "name": "Troupe Juggler Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/59/Mimi-4117_05_troupe_juggler_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/70/Season_of_rhythm_hair_valley_juggle_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Juggler#Hair" },
       "order": 1402
     },
     {
@@ -6190,6 +6298,8 @@
       "type": "Hair",
       "name": "Respectful Pianist Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d8/Mimi-4117_05_respectful_pianist_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1e/Season_of_rhythm_hair_wasteland_respect_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Respectful_Pianist#Hair" },
       "order": 1403
     },
     {
@@ -6405,6 +6515,8 @@
       "type": "Hair",
       "name": "Nodding Muralist Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Mimi-4117_06_nodding_muralist_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/Season_of_enchantment_hair_nodding_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nodding_Muralist#Hair" },
       "order": 1501
     },
     {
@@ -6475,6 +6587,8 @@
       "type": "Hair",
       "name": "Indifferent Alchemist Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Mimi-4117_06_indifferent_alchemist_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/77/Season_of_enchantment_hair_indifferent_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Indifferent_Alchemist#Hair" },
       "order": 1505
     },
     {
@@ -6535,6 +6649,8 @@
       "type": "Hair",
       "name": "Crab Walker Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/Mimi-4117_06_crab_walker_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/39/Season_of_enchantment_hair_crabwalk_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Walker#Hair" },
       "order": 1504
     },
     {
@@ -6638,6 +6754,8 @@
       "type": "Hair",
       "name": "Scarecrow Farmer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fe/Mimi-4117_06_scarecrow_farmer_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1d/Season_of_enchantment_hair_scare_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scarecrow_Farmer#Hair" },
       "order": 1502
     },
     {
@@ -6691,6 +6809,8 @@
       "type": "Hair",
       "name": "Snoozing Carpenter Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9e/Mimi-4117_06_snoozing_carpenter_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/32/Season_of_enchantment_hair_doze_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Snoozing_Carpenter#Hair" },
       "order": 1503
     },
     {
@@ -6792,6 +6912,8 @@
       "type": "Hair",
       "name": "Playfighting Herbalist Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/Mimi-4117_06_playfighting_herbalist_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a7/Season_of_enchantment_hair_playfight_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Hair" },
       "order": 1506
     },
     {
@@ -6860,6 +6982,8 @@
       "type": "Hair",
       "name": "Jelly Whisperer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/Mimi-4117_07_jelly_whisperer_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/Mimi-4117_07_jelly_whisperer_hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jelly_Whisperer#Hair" },
       "order": 1601
     },
     {
@@ -6934,6 +7058,8 @@
       "type": "Hair",
       "name": "Timid Bookworm Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/59/Mimi-4117_07_timid_bookworm_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Season_of_sanctuary_hair_timid_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Timid_Bookworm#Hair" },
       "order": 1602
     },
     {
@@ -6994,6 +7120,8 @@
       "type": "Hair",
       "name": "Rallying Thrillseeker Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/Mimi-4117_07_rallying_thrillseeker_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/95/Season_of_sanctuary_hair_rally_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rallying_Thrillseeker#Hair" },
       "order": 1603
     },
     {
@@ -7099,6 +7227,8 @@
       "type": "Hair",
       "name": "Hiking Grouch Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8e/Mimi-4117_07_hiking_grouch_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5a/Season_of_sanctuary_hair_grouch_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Hair" },
       "order": 1604
     },
     {
@@ -7167,6 +7297,8 @@
       "type": "Hair",
       "name": "Grateful Shell Collector Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Mimi-4117_07_grateful_shell_collector_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/Season_of_sanctuary_hair_grateful_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Grateful_Shell_Collector#Hair" },
       "order": 1605
     },
     {
@@ -7346,6 +7478,8 @@
       "type": "Hair",
       "name": "Prophet of Water Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2d/Mimi-4117_08_prophet_of_water_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9a/Prophecy-Prophet_of_Water_Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Water#Hair" },
       "order": 1701
     },
     {
@@ -7436,6 +7570,8 @@
       "type": "Hair",
       "name": "Prophet of Earth Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/Mimi-4117_08_prophet_of_earth_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/58/Prophecy-Prophet_of_Earth_Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Earth#Hair" },
       "order": 1702
     },
     {
@@ -7539,6 +7675,8 @@
       "type": "Hair",
       "name": "Prophet of Air Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/01/Mimi-4117_08_prophet_of_air_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Prophecy-Prophet_of_Air_Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Air#Hair" },
       "order": 1703
     },
     {
@@ -7641,6 +7779,8 @@
       "type": "Hair",
       "name": "Prophet of Fire Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/22/Mimi-4117_08_prophet_of_fire_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Prophecy-Prophet_of_Fire_Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Hair" },
       "order": 1704
     },
     {
@@ -7776,6 +7916,8 @@
       "type": "Hair",
       "name": "Bearhug Hermit Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Icon_hair_dreams_hermit.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c7/Dreams_hair_bearhug_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bearhug_Hermit#Hair" },
       "order": 1801
     },
     {
@@ -7832,6 +7974,8 @@
       "type": "Hair",
       "name": "Dancing Performer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/14/Icon_hair_dreams_dancing.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3b/Dreams_hair_dancing_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Dancing_Performer#Hair" },
       "order": 1802
     },
     {
@@ -7996,6 +8140,8 @@
       "type": "Hair",
       "name": "Spinning Mentor Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Icon_hair_dreams_3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ab/Dreams_hair_spinning_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Spinning_Mentor#Hair" },
       "order": 1803
     },
     {
@@ -8093,6 +8239,8 @@
       "type": "Hair",
       "name": "Baffled Botanist Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Icon_hair_assembly_baffled.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/Assembly_hair_baffled_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Baffled_Botanist#Hair" },
       "order": 1904
     },
     {
@@ -8205,6 +8353,8 @@
       "type": "Hair",
       "name": "Scolding Student Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/43/Icon_hair_assembly_scolding.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Assembly_hair_scolding_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scolding_Student#Hair" },
       "order": 1905
     },
     {
@@ -8301,6 +8451,8 @@
       "type": "Hair",
       "name": "Scaredy Cadet Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/Icon_hair_assembly_scared.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Assembly_hair_scaredy_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scaredy_Cadet#Hair" },
       "order": 1906
     },
     {
@@ -8355,6 +8507,8 @@
       "type": "Hair",
       "name": "Marching Adventurer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d4/Icon_hair_assembly_march.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/Assembly_hair_marching_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Marching_Adventurer#Hair" },
       "order": 1903
     },
     {
@@ -8592,6 +8746,8 @@
       "type": "Hair",
       "name": "Daydream Forester Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/38/Icon_hair_assembly_daydream.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Assembly_hair_daydream_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Daydream_Forester#Hair" },
       "order": 1902
     },
     {
@@ -8641,6 +8797,8 @@
       "type": "Hair",
       "name": "Beckoning Ruler Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/Icon_hair_prince_king.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/Season_of_little_prince_hair4.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Beckoning_Ruler#Hair" },
       "order": 2004
     },
     {
@@ -8754,6 +8912,8 @@
       "type": "Hair",
       "name": "Gloating Narcissist Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d5/Icon_hair_prince_narcissist.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/61/Season_of_little_prince_hair2.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Gloating_Narcissist#Hair" },
       "order": 2002
     },
     {
@@ -8808,6 +8968,8 @@
       "type": "Hair",
       "name": "Stretching Lamplighter Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Icon_hair_prince_lightkeeper.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/29/Season_of_little_prince_hair3.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stretching_Lamplighter#Hair" },
       "order": 2003
     },
     {
@@ -8871,6 +9033,8 @@
       "type": "Hair",
       "name": "Slouching Soldier Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d7/Icon_hair_prince_shame.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8f/Season_of_little_prince_hair1.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Slouching_Soldier#Hair" },
       "order": 2001
     },
     {
@@ -8953,6 +9117,8 @@
       "type": "Hair",
       "name": "Sneezing Geographer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/69/Icon_hair_prince_sneezing.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Season_of_little_prince_hair5.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sneezing_Geographer#Hair" },
       "order": 2005
     },
     {
@@ -9149,6 +9315,8 @@
       "type": "Hair",
       "name": "Lively Navigator Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3c/Icon_season_of_flight_hair_3_lively_navigator.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d2/Season_of_flight_hair_3_lively_navigator_gs.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lively_Navigator#Hair" },
       "order": 2104
     },
     {
@@ -9243,6 +9411,8 @@
       "type": "Hair",
       "name": "Light Whisperer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/Icon_season_of_flight_hair_4_light_whisperer.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/12/Season_of_flight_hair_4_light_whisperer_gs.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Light_Whisperer#Hair" },
       "order": 2103
     },
     {
@@ -9333,6 +9503,8 @@
       "type": "Hair",
       "name": "Tinkering Chimesmith Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9e/Icon_season_of_flight_hair_2_tinkering_chimesmith.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/Season_of_flight_hair_2_tinkering_chimesmith.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tinkering_Chimesmith#Hair" },
       "order": 2102
     },
     {
@@ -9432,6 +9604,8 @@
       "type": "Hair",
       "name": "Talented Builder Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Icon_season_of_flight_hair_1_talented_builder.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Season_of_flight_hair_1_talented_builder_gs.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Talented_Builder#Hair" },
       "order": 2101
     },
     {
@@ -9478,6 +9652,8 @@
       "type": "Hair",
       "name": "Anxious Angler Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e7/SOAbyss-Anxious-Angler-hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/63/SOAbyss-Anxious-Angler-hat-screenshot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Anxious_Angler#Hair" },
       "order": 2203
     },
     {
@@ -9561,6 +9737,8 @@
       "type": "Hair",
       "name": "Ceasing Commodore Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ee/SOAbyss-Ceasing-Commodore-hairstyle.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/SOAbyss-Ceasing-Commodore-hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ceasing_Commodore#Hair" },
       "order": 2202
     },
     {
@@ -9783,6 +9961,8 @@
       "type": "Hair",
       "name": "Cackling Cannoneer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/99/SOAbyss-Cackling-Cannoneer-hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/SOAbyss-Cackling-Cannoneer-Cape-hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Cackling_Cannoneer#Hair" },
       "order": 2201
     },
     {
@@ -9830,6 +10010,8 @@
       "type": "Hair",
       "name": "Frantic Stagehand Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/SoPerformance_-_Frantic_Stagehand-hairstyle-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/SoPerformance_-_Frantic_Stagehand-hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frantic_Stagehand#Hair" },
       "order": 2303
     },
     {
@@ -9918,6 +10100,8 @@
       "type": "Hair",
       "name": "Forgetful Storyteller Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/SoPerformance_-_Forgetful_Storyteller-hairstyle-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/SoPerformance_-_Forgetful_Storyteller-hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forgetful_Storyteller#Hair" },
       "order": 2304
     },
     {
@@ -10050,6 +10234,8 @@
       "type": "Hair",
       "name": "Mellow Musician Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/Morybel-0146-SoPerformance_-_Mellow_Musician-hairstyle-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/SoPerformance_-_Mellow_Musician-hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mellow_Musician#Hair" },
       "order": 2305
     },
     {
@@ -10127,6 +10313,8 @@
       "type": "Hair",
       "name": "Modest Dancer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/SOPerformance-Modest-Dancer-hairstyle-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/SOPerformance-Modest-Dancer-_Hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Modest_Dancer#Hair" },
       "order": 2302
     },
     {
@@ -10143,6 +10331,8 @@
       "type": "Hair",
       "name": "Jellyfish Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/SOShattering-Light-hairstyle-royal-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/SOShattering-Light-hairstyle-royal.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Light#Hair" },
       "order": 2403
     },
     {
@@ -10208,6 +10398,8 @@
       "type": "Hair",
       "name": "Manta Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/51/SOShattering-Light-Hairstyle-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/SOShattering-Light-Hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Light#Hair" },
       "order": 2402
     },
     {
@@ -10339,6 +10531,8 @@
       "type": "Hair",
       "name": "Dragon Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/SOShattering-Dark-Dragon-hairstyle-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/SOShattering-Dark-Dragon-hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Darkness#Hair" },
       "order": 2401
     },
     {
@@ -10397,6 +10591,8 @@
       "type": "Hair",
       "name": "Running Wayfarer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b1/SoAurora-Running-Wayfarer-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/SoAurora-Running-Wayfarer-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Running_Wayfarer#Hair" },
       "order": 2502
     },
     {
@@ -10496,6 +10692,8 @@
       "type": "Hair",
       "name": "Mindful Miner Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/68/SoAurora-Mindful-Miner-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6c/SoAurora-Mindful-Miner-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mindful_Miner#Hair" },
       "order": 2504
     },
     {
@@ -10581,6 +10779,8 @@
       "type": "Hair",
       "name": "Warrior of Love Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6b/SoAurora-Warrior-of-Love-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2f/SoAurora-Warrior-of-Love-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Warrior_of_Love#Hair" },
       "order": 2503
     },
     {
@@ -10693,6 +10893,8 @@
       "type": "Hair",
       "name": "Seed of Hope Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/SoAurora-Seed-of-Hope-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/SoAurora-Seed-of-Hope-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Seed_of_Hope#Hair" },
       "order": 2501
     },
     {
@@ -10736,6 +10938,8 @@
       "type": "Hair",
       "name": "AURORA Runaway Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/62/Aurora-Runaway-Hair-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/SoAurora-Short-bang-hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Hair" },
       "order": 2505
     },
     {
@@ -10845,6 +11049,8 @@
       "type": "Hair",
       "name": "Bereft Veteran Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/SoRemembrance-Bereft-Veteran-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6d/SoRemembrance-Bereft-Veteran-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bereft_Veteran#Hair" },
       "order": 2602
     },
     {
@@ -10922,6 +11128,8 @@
       "type": "Hair",
       "name": "Pleading Child Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/SoRemembrance-Pleading-Child-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/SoRemembrance-Pleading-Child-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Hair" },
       "order": 2601
     },
     {
@@ -10995,6 +11203,8 @@
       "type": "Hair",
       "name": "Tiptoeing Tea-Brewer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/79/SoRemembrance-Tiptoeing-Tea-Brewer-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4c/SoRemembrance-Tiptoeing-Tea-Brewer-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tiptoeing_Tea-Brewer#Hair" },
       "order": 2603
     },
     {
@@ -11125,6 +11335,8 @@
       "type": "Hair",
       "name": "Oddball Outcast Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/23/Passage-Oddball-Outcast-Hairstyle-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/08/Passage-Oddball-Outcast-Hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Oddball_Outcast#Hair" },
       "order": 2704
     },
     {
@@ -11210,6 +11422,8 @@
       "type": "Hair",
       "name": "Tumbling Troublemaker Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/Passage-Tumbling-Troublemaker-Hair-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/24/Passage-Tumbling-Troublemaker-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tumbling_Troublemaker#Hair" },
       "order": 2701
     },
     {
@@ -11302,6 +11516,8 @@
       "type": "Hair",
       "name": "Melancholy Mope Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/96/Passage-Melancholy-Mope-Hair-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/Passage-Melancholy-Mope-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Hair" },
       "order": 2702
     },
     {
@@ -11406,6 +11622,8 @@
       "type": "Hair",
       "name": "Overactive Overachiever Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/18/Passage-Overactive-Overachiever-Hair-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ea/Passage-Overactive-Overachiever-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Overactive_Overachiever#Hair" },
       "order": 2703
     },
     {
@@ -11523,6 +11741,8 @@
       "type": "Hair",
       "name": "Jolly Geologist Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/Jolly-Geologist-Hair-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e2/Jolly-Geologist-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jolly_Geologist#Hair" },
       "order": 2803
     },
     {
@@ -11607,6 +11827,8 @@
       "type": "Hair",
       "name": "Ascetic Monk Tattoo",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7e/Ascetic-Monk-Hair-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Ascetic-Monk-Hair-back.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ascetic_Monk#Hair" },
       "order": 2802
     },
     {
@@ -11663,6 +11885,8 @@
       "type": "Hair",
       "name": "Nightbird Whisperer Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/eb/Nightbird-Whisperer-Hair-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Nightbird-Whisperer-Hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nightbird_Whisperer#Hair" },
       "order": 2801
     },
     {
@@ -11738,6 +11962,8 @@
       "type": "Hair",
       "name": "Days of Fortune Lion Headdress",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/Icon_hair_new_years_headpiece.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e5/Chinese_new_year_hat_hair_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Lion_Headdress" },
       "order": 352
     },
     {
@@ -11752,6 +11978,8 @@
       "type": "Hair",
       "name": "Days of Fortune Wool Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/65/Icon_hair_event_wool_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Wool_hat_hair_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Wool_Hat" },
       "order": 301
     },
     {
@@ -11775,6 +12003,8 @@
       "type": "Hair",
       "name": "Days of Fortune Bun Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Icon_hair_event_high_buns.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Days_of_fortune_hair_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Bun_Hair" },
       "order": 351
     },
     {
@@ -11805,6 +12035,8 @@
       "type": "Hair",
       "name": "Days of Fortune Fish Hood",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/Days_of_Fortune_-_Fish_head_iconl.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/Days-of-fortune-hair-hat.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Fish_Hood" },
       "order": 501
     },
     {
@@ -12022,6 +12254,8 @@
       "type": "Hair",
       "name": "Bloom Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/Icon_hair_bloom.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4f/Days_of_blossom_2021_hair_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Bloom_Hair" },
       "order": 601
     },
     {
@@ -12294,8 +12528,10 @@
     {
       "guid": "cMLcvRtjoh",
       "type": "Hair",
-      "name": "Rainbow Hat",
+      "name": "Rainbow Beanie Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/43/Icon_hair_rainbow_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bd/Rainbow_hair_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Rainbow_Beanie_Hat" },
       "order": 701
     },
     {
@@ -12637,6 +12873,8 @@
       "type": "Hair",
       "name": "Hungry Pumpkin Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/Icon_hair_mischief_pumpkin.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d5/Hair_halloween_pumpkin.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Hungry_Pumpkin_Hat" },
       "order": 101
     },
     {
@@ -12644,6 +12882,8 @@
       "type": "Hair",
       "name": "Mischief Witch Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/95/Icon_hair_mischief_witch_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/Crooked_witch_hat_hair_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Hat" },
       "order": 102
     },
     {
@@ -12690,6 +12930,8 @@
       "type": "Hair",
       "name": "Mischief Witch Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/Icon_2021_mischief_long_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/12/Hair_2021_mischief_long_hair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Hair" },
       "order": 104
     },
     {
@@ -12704,6 +12946,8 @@
       "type": "Hair",
       "name": "Mischief Spider Quiff",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cc/Icon_2021_mischief_iap_hair.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Hair_2021_mischief_web_hair_iap.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Spider_Quiff" },
       "order": 103
     },
     {
@@ -12738,6 +12982,8 @@
       "type": "Hair",
       "name": "Mischief Tufted Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6a/Days-of-Mischief-Cat-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/Days-of-Mischief-2022-Cat-hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Tufted_Hair" },
       "order": 105
     },
     {
@@ -12770,6 +13016,8 @@
       "type": "Hair",
       "name": "Feast Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/82/Icon_hair_feast_santa_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/Santa_hat.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Feast_Hat" },
       "order": 201
     },
     {
@@ -12853,6 +13101,8 @@
       "type": "Hair",
       "name": "Winter Feast Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4d/Days_of_Feast_Whool_hat_icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d1/Wool_hat_hair_2021.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Winter_Feast_Hat" },
       "order": 202
     },
     {
@@ -13010,6 +13260,8 @@
       "type": "Hair",
       "name": "Kizuna AI Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Kizuna-AI-Hairstyle-Icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Kizuna-AI-Hairstyle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Kizuna_AI_Hair" },
       "order": 401
     },
     {
@@ -13162,6 +13414,8 @@
       "type": "Hair",
       "name": "Marching Band Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/70/Harmony-Hall-Marching-Band-Hat-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/Musical-Hall-Marching-Band-Hat.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Music#Harmony_Hall_Marching_Band_Hat" },
       "order": 326
     },
     {
@@ -13264,6 +13518,8 @@
       "type": "Hair",
       "name": "Nintendo Elf Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/64/Icon_hair_Nintendo_elf.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a7/Nintendo_elf_hair_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_for_Nintendo_Switch#Nintendo_Pack" },
       "order": 801
     },
     {
@@ -13296,6 +13552,8 @@
       "type": "Hair",
       "name": "Journey Hair",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e9/Journey-Pack-Hairstyle-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1e/JourneyPack-Hair-Nastymold.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Journey_Pack" },
       "order": 901
     },
     // #endregion

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -3432,6 +3432,8 @@
       "type": "Hat",
       "name": "Flight Ultimate Hair Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d3/Icon_season_of_flight_headpiece_4_ult.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/51/Season_of_flight_headpiece_4_ult.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Flight_Guide#Ultimate_Gifts" },
       "order": 2104
     },
     {
@@ -4533,6 +4535,8 @@
       "name": "Moments Ultimate Hat",
       "group": "Ultimate",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3f/Moments-Guide-Ultimate-Hair-accessory-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/83/Moments-Guide-Ultimate-Hair-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Moments_Guide#Ultimate_Gifts" },
       "order": 2801
     },
     // #endregion
@@ -7403,6 +7407,8 @@
       "type": "Hat",
       "name": "Chill Sunbather Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6d/Mimi-4117_07_chill_sunbather_hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/49/Season_of_sanctuary_hair_chill_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chill_Sunbather#Hair" },
       "order": 1
     },
     {
@@ -9324,6 +9330,8 @@
       "type": "Hat",
       "name": "Lively Navigator Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d2/Icon_season_of_flight_headpiece_2_lively_navigator.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Season_of_flight_headpiece_2_lively_navigator.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lively_Navigator#Hair_Accessory" },
       "order": 2103
     },
     {
@@ -9404,6 +9412,8 @@
       "type": "Hat",
       "name": "Light Whisperer Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Icon_season_of_flight_headpiece_1_light_whisperer.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Season_of_flight_headpiece_1_light_whisperer.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Light_Whisperer#Hair_Accessory" },
       "order": 2101
     },
     {
@@ -9477,6 +9487,8 @@
       "type": "Hat",
       "name": "Tinkering Chimesmith Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/68/Icon_season_of_flight_headpiece_3_tinkering_chimesmith.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7f/Season_of_flight_headpiece_3_tinkering_chimesmith.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tinkering_Chimesmith#Hair_Accessory" },
       "order": 2102
     },
     {
@@ -9865,6 +9877,8 @@
       "type": "Hat",
       "name": "Bumbling Boatswain Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6c/SOAbyss-Bumbling-Boatswain-hat.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d4/SOAbyss-Bumbling-Boatswain-Cape-hat-screenshot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bumbling_Boatswain#Hair_Accessory" },
       "order": 2201
     },
     {
@@ -10352,6 +10366,8 @@
       "type": "Hat",
       "name": "Jellyfish Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ec/SOShattering-Light-Hair-accessory-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b1/SOShattering-Light-Hair-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Light#Hair_Accessory" },
       "order": 2402
     },
     {
@@ -10442,6 +10458,8 @@
       "type": "Hat",
       "name": "Darkness Plant Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3f/SOShattering-Dark-Hair-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/SOShattering-Dark-Hair-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Darkness#Hair_Accessory" },
       "order": 2401
     },
     {
@@ -11697,6 +11715,8 @@
       "type": "Hat",
       "name": "Reassuring Ranger Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b8/Reassuring-Ranger-Hair-accessory-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/53/Reassuring-Ranger-Hair-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Reassuring_Ranger#Hair_Accessory" },
       "order": 2803
     },
     {
@@ -11906,6 +11926,8 @@
       "type": "Hat",
       "name": "Nightbird Whisperer Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/Nightbird-Whisperer-Head-accessory-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a3/Nightbird-Whisperer-Head-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nightbird_Whisperer#Hair_Accessory" },
       "order": 2802
     },
     {
@@ -11969,9 +11991,11 @@
     {
       "guid": "aRgiKoKavp",
       "type": "Hat",
-      "name": "Days of Fortune Orange",
+      "name": "Days of Fortune Orange Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Icon_hair_event_orange_headpiece.png",
-      "order": 11101
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a9/Orange_headpiece_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Orange" },
+      "order": 11201
     },
     {
       "guid": "udspGJd38_",
@@ -12021,6 +12045,8 @@
       "type": "Hat",
       "name": "Days of Fortune Fish Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c5/Days_of_Fortune_-_Fish_accessory_Icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1f/Days-of-fortune-fish-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Fish_Accessory" },
       "order": 11301
     },
     {
@@ -12160,6 +12186,8 @@
       "type": "Hat",
       "name": "Days of Love Flower Crown",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/Days_of_Love_-_Flower_head_accessory-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Days_of_Love_-_Flower_head_accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love#Days_of_Love_Flower_Crown" },
       "order": 10201
     },
     {
@@ -12385,6 +12413,8 @@
       "type": "Hat",
       "name": "Nature Coral Crown",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d2/Days-of-Nature-2022-Coral-Hair-accessory-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Days-of-Nature-2022-Coral-Hair-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Nature_Coral_Crown_Accessory" },
       "order": 10401
     },
     {
@@ -12523,6 +12553,8 @@
       "type": "Hat",
       "name": "Rainbow Hair Flower",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/57/Icon_hair_rainbow_flower.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0a/Rainbow_flower_headpiece_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Rainbow_Hair_Flower" },
       "order": 10101
     },
     {
@@ -12539,6 +12571,8 @@
       "type": "Hat",
       "name": "Double Rainbow Flower",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/85/Days-of-Rainbow-2022-Double-Rainbow-flower-accessory-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/16/Days-of-Rainbow-2022-Double-Rainbow-flower-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Double_Rainbow_Flower" },
       "order": 10102
     },
     {
@@ -12618,6 +12652,8 @@
       "type": "Hat",
       "name": "1 Year Sky Anniversary Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a2/Icon_hair_sky_anniversary_1.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/1st_anniv_hat_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#1_Year_Anniversary_Hat" },
       "order": 10701
     },
     {
@@ -12625,6 +12661,8 @@
       "type": "Hat",
       "name": "2 Year Sky Anniversary Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f3/Icon_hair_sky_anniversary_2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/2nd_anniversary_hat_front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#2nd_Birthday_Hat" },
       "order": 10702
     },
     {
@@ -12693,6 +12731,8 @@
       "type": "Hat",
       "name": "3 Year Sky Anniversary Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Days-of-Sky-2022-anniversary-crown-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b1/Days-of-Sky-2022-anniversary-crown.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#3rd_Birthday_Hat" },
       "order": 10703
     },
     {
@@ -12759,6 +12799,8 @@
       "name": "4 Year Sky Anniversary Hat",
       "type": "Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/Sky-4th-Anniversary-Hat-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/Sky-4th-Anniversary-Hat.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#4th_Anniversary_Hat" },
       "order": 10704
     },
     {
@@ -12836,7 +12878,10 @@
       "guid": "o4cIshT_hD",
       "name": "Style Top Hat",
       "type": "Hat",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Style-Tophat-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Style-Tophat-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/Style-Tophat.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Style#Style_Top_Hat" },
+      "order": 11501
     },
     {
       "guid": "TbSEPp5DAI",
@@ -13144,6 +13189,8 @@
       "type": "Hat",
       "name": "Snowflake Hair Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/Days_of_Feast_Snowflake_icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Snowflake_Pin.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Snowflake_Hair_Accessory" },
       "order": 11001
     },
     {
@@ -13197,6 +13244,8 @@
       "type": "Hat",
       "name": "Flower Hair Accessory",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/Icon_hair_event_healing_poppy.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/03/Days_of_heeling_poppy_headpiece_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Healing#Healing_Flower_Hair_Accessory" },
       "order": 10001
     },
     // #endregion
@@ -13215,7 +13264,9 @@
       "type": "Hat",
       "name": "Summer Lights Bunny Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/Icon_hair_event_bunny_head.png",
-      "order": 11201
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/Bunny_head_accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lazy_Days#Bunny_Accessory" },
+      "order": 11101
     },
     // #endregion
     // #region Days of Summer (2021)
@@ -13237,6 +13288,8 @@
       "type": "Hat",
       "name": "Days of Summer Hat",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Icon_hair_summer_hat_headpiece.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Days_of_summer_headpiece_hat.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lazy_Days#Summer_Hat" },
       "order": 10501
     },
     {
@@ -13251,6 +13304,8 @@
       "type": "Hat",
       "name": "Days of Summer Shell Hairpin",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/Icon_hair_summer_shell_pin_headpiece.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/79/Days_of_summer_Hair_accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Lazy_Days#Seashell_Hairpin" },
       "order": 10301
     },
     // #endregion
@@ -13269,6 +13324,8 @@
       "type": "Hat",
       "name": "Kizuna AI Bow",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/Kizuna-AI-Hair-Accessory-Icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/Kizuna-AI-Hair-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Kizuna_AI#Kizuna_AI_Bow" },
       "order": 11401
     },
     {
@@ -13400,6 +13457,8 @@
       "type": "Hat",
       "name": "Musical Hairpin",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f2/SOPerformance-hair-accessory-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/ba/SOPerformance-hair-accessory.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Harmony_Hall#Musical_Hairpin" },
       "order": 10801
     },
     {

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -45,6 +45,7 @@
       "guid": "cj9Kr-LnJs",
       "type": "Stance",
       "name": "Base Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Expressions#Stances" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/Stance_basic_stand.png",
       "unlocked": true,
       "order": 1
@@ -53,6 +54,7 @@
       "guid": "_59vOU9i2_",
       "type": "Call",
       "name": "Base Call",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Expressions#Base_Call" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7c/Voice_basic_call.png",
       "unlocked": true,
       "order": 1
@@ -688,6 +690,7 @@
       "guid": "FGr955bSRr",
       "type": "Call",
       "name": "Bird Call",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bird_Whisperer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/BirdWhisperer-1.png",
       "order": 11
     },
@@ -1389,6 +1392,7 @@
       "guid": "70FpYsoCa7",
       "type": "Call",
       "name": "Whale Call",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Whale_Whisperer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fe/WhaleWhisperer-1.png",
       "order": 21
     },
@@ -1430,6 +1434,7 @@
       "guid": "HdmcYW9N-f",
       "type": "Stance",
       "name": "Confident Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confident_Sightseer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c8/ConfidentSightseer-1.png",
       "order": 21
     },
@@ -1562,6 +1567,7 @@
       "guid": "XyTNAnvs9N",
       "type": "Call",
       "name": "Manta Call",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Manta_Whisperer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/38/MantaWhisperer-1.png",
       "order": 31
     },
@@ -1829,6 +1835,7 @@
       "guid": "6Gz1udO5fI",
       "type": "Stance",
       "name": "Proud Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Proud_Victor#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dc/ProudVictor-1.png",
       "order": 41
     },
@@ -2048,6 +2055,7 @@
       "guid": "dCMS94p34P",
       "type": "Stance",
       "name": "Courageous Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Courageous_Soldier#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9e/CourageousSoldier-1.png",
       "order": 11
     },
@@ -2113,6 +2121,7 @@
       "guid": "ztAW0vBZfY",
       "type": "Stance",
       "name": "Sneaky Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Stealthy_Survivor#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/StealthySurvivor-1.png",
       "order": 31
     },
@@ -2484,6 +2493,7 @@
       "guid": "I1fk2fnGDK",
       "type": "Call",
       "name": "Cosmic Manta Call",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Memory_Whisperer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ea/MemoryWhisperer-1.png",
       "order": 41
     },
@@ -2549,6 +2559,7 @@
       "guid": "8QnR-XHmJg",
       "type": "Stance",
       "name": "Polite Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Polite_Scholar#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/PoliteScholar-1.png",
       "order": 51
     },
@@ -4779,6 +4790,7 @@
       "guid": "SadZcfujh7",
       "type": "Stance",
       "name": "Sassy Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sassy_Drifter#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Mimi-4117_02_sassy_drifter_emote.png",
       "order": 61
     },
@@ -5361,6 +5373,7 @@
       "guid": "_o__3iD1Rh",
       "type": "Stance",
       "name": "Laidback Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Laidback_Pioneer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Mimi-4117_03_laidback_pioneer_emote.png",
       "order": 71
     },
@@ -5524,6 +5537,7 @@
       "guid": "ySbxSrn-4l",
       "type": "Call",
       "name": "Crab Call",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Whisperer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/20/Mimi-4117_03_crab_whisperer_emote.png",
       "order": 51
     },
@@ -5962,6 +5976,7 @@
       "guid": "N_FirAVIZf",
       "type": "Stance",
       "name": "Wise Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wise_Grandparent#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/36/Belonging_stance_think.png",
       "order": 81
     },
@@ -7350,6 +7365,7 @@
       "guid": "U7lPqW1fa0",
       "type": "Call",
       "name": "Jellyfish Call",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jelly_Whisperer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/SoS_jelly_fish_call.png",
       "order": 61
     },
@@ -7428,6 +7444,7 @@
       "guid": "QnA3xwSNod",
       "type": "Stance",
       "name": "Timid Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Timid_Bookworm#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d3/SoS_shy_stance.png",
       "order": 91
     },
@@ -9945,6 +9962,7 @@
       "guid": "YiLDQF0uDU",
       "type": "Call",
       "name": "Baby Manta Call",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Light_Whisperer#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/Season_of_Flight_-_Light_Whisperer_icon.png",
       "order": 71
     },
@@ -10013,6 +10031,7 @@
       "guid": "Jgp0s63dVZ",
       "type": "Stance",
       "name": "Tinker Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tinkering_Chimesmith#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/03/Season_of_Flight_-_Tinkering_Chimesmith_icon.png",
       "order": 101
     },
@@ -11931,6 +11950,7 @@
       "guid": "6dT44er9LL",
       "type": "Stance",
       "name": "Injured Stance",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wounded_Warrior#Expression" },
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/SoRemembrance-Wounded-Warrior-Emote-Icon-Morybel-0146.png",
       "order": 111
     },
@@ -12589,7 +12609,9 @@
       "guid": "7j3bbradN0",
       "type": "Call",
       "name": "Nightbird Call",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Nightbird-Whisperer-Call-icon-Credit-Morybel.png"
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nightbird_Whisperer#Expression" },
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Nightbird-Whisperer-Call-icon-Credit-Morybel.png",
+      "order": 81
     },
     {
       "guid": "ygFxGKMla2",

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -2370,8 +2370,10 @@
     {
       "guid": "EdxE5UGZsa",
       "type": "Prop",
-      "name": "Meditating Monastic Prop",
+      "name": "Meditating Monastic Table Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/47/Meditating-Monastic-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8f/Instrument-Chat_Table_Chair.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Meditating_Monastic#Prop" },
       "order": 101
     },
     // Memory Whisperer
@@ -2749,6 +2751,8 @@
       "group": "Ultimate",
       "name": "Belonging Ultimate Fireplace",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/Icon_prop_belonging_bonfire.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9c/Season_of_belonging_ultimate_bonfire.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Belonging_Guide#Ultimate_Gifts" },
       "order": 901
     },
     // #endregion
@@ -3268,6 +3272,8 @@
       "type": "Prop",
       "name": "Assembly Pillow",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/03/Icon_prop_assembly_pillow.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e5/Prop_forest_treehouse_pillow.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Pillow" },
       "order": 1601
     },
     {
@@ -3299,6 +3305,8 @@
       "type": "Prop",
       "name": "Assembly Jar",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Icon_prop_pot.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Assembly_prop_pot_down.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Jar" },
       "order": 1501
     },
     {
@@ -3312,6 +3320,8 @@
       "type": "Prop",
       "name": "Assembly Brazier",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/21/Icon_prop_assembly_brazier.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7c/Prop_forest_treehouse_brazier.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Brazier" },
       "order": 1201
     },
     {
@@ -3337,6 +3347,8 @@
       "type": "Prop",
       "name": "Assembly Bookcase",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dc/Icon_prop_bookcase.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/20/Assembly_prop_bookcase_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Bookcase" },
       "order": 1301
     },
     {
@@ -3344,6 +3356,8 @@
       "type": "Prop",
       "name": "Assembly Tent",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/Icon_prop_assembly_tent.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/Prop_forest_treehouse_tent.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Tent" },
       "order": 1801
     },
     // #endregion
@@ -3384,6 +3398,8 @@
       "group": "Ultimate",
       "name": "Little Prince Ultimate Rose",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/Icon_prop_little_prince_rose.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1c/Season_of_little_prince_inst2rose_ultimate.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Rose#Ultimate_Gifts" },
       "order": 2201
     },
     {
@@ -3850,6 +3866,8 @@
       "type": "Prop",
       "name": "Performance Flower Pot Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/SOPerformance-flower-pot-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/SOPerformance-flower-pot.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Performance_Guide#Prop" },
       "order": 2401
     },
     // #endregion
@@ -4198,6 +4216,8 @@
       "type": "Prop",
       "name": "Remembrance Ultimate Manta Projector",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1d/SoRemembrance-Ultimate-Gift-Manta-Projector-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/50/SoRemembrance-Ultimate-Gift-Manta-Projector.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Ultimate_Gifts" },
       "order": 2801
     },
     {
@@ -4223,6 +4243,8 @@
       "type": "Prop",
       "name": "Remembrance Chimes Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c9/SoRemembrance-Prop-Chimes-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/SoRemembrance-Prop-Chimes.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Chimes" },
       "order": 2501
     },
     {
@@ -4260,6 +4282,8 @@
       "type": "Prop",
       "name": "Remembrance Kettle",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/SoRemembrance-Prop-Kettle-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/SoRemembrance-Prop-Kettle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Kettle" },
       "order": 2701
     },
     {
@@ -4297,6 +4321,8 @@
       "type": "Prop",
       "name": "Remembrance Potted Plant",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/SoRemembrance-Prop-Plants-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/SoRemembrance-Prop-Plants.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Potted_Plant" },
       "order": 2601
     },
     {
@@ -4322,6 +4348,8 @@
       "type": "Prop",
       "name": "Remembrance Crab Plush",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ab/SoRemembrance-Prop-Crab-Plush-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/18/Remembrance-Prop-Crab-Plush.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Crab_Plush" },
       "order": 2901
     },
     {
@@ -4329,6 +4357,8 @@
       "type": "Prop",
       "name": "Remembrance Manta Plush",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c2/SoRemembrance-Prop-Manta-Plush-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/85/Remembrance-Prop-Manta-Plush.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Manta_Plush" },
       "order": 3001
     },
     {
@@ -4455,6 +4485,8 @@
       "type": "Prop",
       "name": "Hacky Sack Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/Passage-Hacky-Sack-prop-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4b/Passage-Hacky-Sack-prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Passage_Guide#Hacky_Sack" },
       "order": 3101
     },
     {
@@ -5411,6 +5443,8 @@
       "type": "Prop",
       "name": "Crab Whisperer Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4f/Icon_prop_summer_tube.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/Summer_prop_tube_down.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Crab_Whisperer#Prop" },
       "order": 801
     },
     {
@@ -5754,8 +5788,10 @@
     {
       "guid": "3KTXA81fSx",
       "type": "Prop",
-      "name": "Sparkler Parent Prop",
+      "name": "Sparkler Parent Pinwheel Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Spell_-_Pinwheel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/91/Pinwheel_.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sparkler_Parent#Prop" },
       "order": 3801
     },
     // Wise Grandparent
@@ -5844,6 +5880,8 @@
       "type": "Prop",
       "name": "Wise Grandparent Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6c/Icon_prop_vault_lantern.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ac/Wise_grandparent_book.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wise_Grandparent#Prop" },
       "order": 301
     },
     // Pleaful Parent
@@ -6206,6 +6244,8 @@
       "type": "Prop",
       "name": "Festival Spin Dancer Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/Icon_prop_rhythm_flag.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Festival_spin_dancers_flag.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Festival_Spin_Dancer#Prop" },
       "order": 201
     },
     // Admiring Actor
@@ -6379,6 +6419,8 @@
       "type": "Prop",
       "name": "Troupe Juggler Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f5/Icon_prop_torch_lantern.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/Summer_prop_lantern_out.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Juggler#Prop" },
       "order": 1001
     },
     {
@@ -7082,6 +7124,8 @@
       "type": "Prop",
       "name": "Playfighting Herbalist Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Shiny-orb.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Playfighting-herbalist-orb-prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Prop" },
       "order": 401
     },
     // #endregion
@@ -7160,6 +7204,8 @@
       "type": "Prop",
       "name": "Jelly Whisperer Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/55/Jelly_whisperer_TS_beach_umbrella_icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Jelly_whisperers_beach_umbrella.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jelly_Whisperer#Prop" },
       "order": 4301
     },
     // Timid Bookworm
@@ -7473,6 +7519,8 @@
       "type": "Prop",
       "name": "Grateful Shell Collector Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/66/Icon_prop_summer_chairs.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/Summer_prop_chairs.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Grateful_Shell_Collector#Prop" },
       "order": 4501
     },
     {
@@ -7573,6 +7621,8 @@
       "type": "Prop",
       "name": "Chill Sunbather Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/49/Icon_prop_summer_lounger.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Prop_beach_lounger.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chill_Sunbather#Prop" },
       "order": 4401
     },
     {
@@ -7675,6 +7725,8 @@
       "type": "Prop",
       "name": "Prophet of Water Sticker",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b0/SoProphecy-Prophet-of-Water-Sticker-Prop-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/69/SoProphecy-Prophet-of-Water-Prop-image-Morybel-0146.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Water#Prop" },
       "order": 501
     },
     {
@@ -7776,6 +7828,8 @@
       "type": "Prop",
       "name": "Prophet of Earth Sticker",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Icon_prop_prophet_of_earth_.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/75/Prophet_of_earth_prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Earth#Prop" },
       "order": 601
     },
     {
@@ -7882,6 +7936,8 @@
       "type": "Prop",
       "name": "Prophet of Air Sticker",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4b/Prophet-of-air-prop-Ray.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/Prophet_of_air_sticker.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Air#Prop" },
       "order": 701
     },
     {
@@ -7995,6 +8051,8 @@
       "type": "Prop",
       "name": "Prophet of Fire Cauldron",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/76/Fire_of_Prophet_TS_cauldron.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Fire_prophet%3Fs_cauldron_.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Prop" },
       "order": 1101
     },
     {
@@ -8002,6 +8060,8 @@
       "type": "Prop",
       "name": "Prophet of Fire Sticker",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4b/SoProphecy-Prophet-of-Fire-Sticker-Prop-Icon-Ed.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/SoProphecy-Prophet-of-Fire-Prop-Sticker-image-Ed.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Prop" },
       "order": 702
     },
     // #endregion
@@ -8435,6 +8495,8 @@
       "type": "Prop",
       "name": "Baffled Botanist Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c6/Icon_prop_assembly_lamp.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/56/Baffled-botanist-spotlight-prop-closeup.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Baffled_Botanist#Prop" },
       "order": 1901
     },
     {
@@ -8612,8 +8674,10 @@
     {
       "guid": "1tF2KjdUWO",
       "type": "Prop",
-      "name": "Scaredy Cadet Prop",
+      "name": "Scaredy Cadet Hammock",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Icon_prop_assembly_hammock.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/Assembly_prop_hammock_down.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Scaredy_Cadet#Prop" },
       "order": 1401
     },
     {
@@ -8703,8 +8767,10 @@
     {
       "guid": "deXq8qb84g",
       "type": "Prop",
-      "name": "Marching Adventurer Prop",
+      "name": "Marching Adventurer Tiki Torch",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Icon_prop_assembly_torch.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/30/Assembly_prop_torch_lit_2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Marching_Adventurer#Prop" },
       "order": 1701
     },
     {
@@ -8805,6 +8871,8 @@
       "type": "Prop",
       "name": "Chuckling Scout Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4b/Icon_prop_assembly_hoop.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4d/Assembly_prop_hoop_down.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Prop" },
       "order": 2001
     },
     {
@@ -9398,6 +9466,8 @@
       "type": "Prop",
       "name": "Star Collector Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Icon_prop_little_prince_star_prop.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e7/Star-collector-star-lamp-prop-closeup.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Star_Collector#Prop" },
       "order": 2101
     },
     {
@@ -9449,6 +9519,8 @@
       "type": "Prop",
       "name": "Little Prince Fox",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6c/Icon_prop_little_prince_fox.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/Season_of_little_prince_iap_fox_inst.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Rose#Prop" },
       "order": 2301
     },
     // #endregion
@@ -12019,6 +12091,8 @@
       "type": "Prop",
       "name": "Jolly Geologist Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Jolly-Geologist-Prop-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b5/Jolly-Geologist-Prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jolly_Geologist#Prop" },
       "order": 3201
     },
     {
@@ -12385,6 +12459,8 @@
       "type": "Prop",
       "name": "Days of Love Swing",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Icon_prop_days_of_love_swing.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d4/Swing_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love#Days_of_Love_Swing" },
       "order": 3101
     },
     {
@@ -12401,6 +12477,8 @@
       "type": "Prop",
       "name": "Days of Love Seesaw",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a7/Icon_prop_days_of_love_seesaw.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ea/Seesaw_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love#Days_of_Love_Seesaw" },
       "order": 3201
     },
     {
@@ -12417,6 +12495,8 @@
       "type": "Prop",
       "name": "Days of Love Gondola",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1f/Days_of_Love_Gondola_icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/71/Gondola_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love#Days_of_Love_Gondola" },
       "order": 3301
     },
     {
@@ -12424,6 +12504,8 @@
       "type": "Prop",
       "name": "Days of Love Flowery Archway",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/eb/Days-of-Love-Arch-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/Days-of-Love-Flowery-Archway.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love#Days_of_Love_Flowery_Archway" },
       "order": 3401
     },
     {
@@ -12517,6 +12599,8 @@
       "type": "Prop",
       "name": "Pink Bloom Teaset",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f3/Icon_prop_days_of_bloom_tea_table.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/53/Tea_table_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Bloom_Teaset" },
       "order": 3501
     },
     {
@@ -12551,6 +12635,8 @@
       "type": "Prop",
       "name": "Purple Bloom Teaset",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/33/Purple_Bloom_Teaset_icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/96/Wisteria-teaset-iap-image.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Purple_Bloom_Teaset" },
       "order": 3701
     },
     {
@@ -12573,6 +12659,8 @@
       "type": "Prop",
       "name": "Bloom Butterfly Fountain",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8e/Days-of-Bloom-Butterfly-Fountain-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/03/Days-of-Bloom-Butterfly-Fountain.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Bloom_Butterfly_Fountain" },
       "order": 5601
     },
     {
@@ -12595,6 +12683,8 @@
       "type": "Prop",
       "name": "Bloom Picnic Basket",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/Days-of-Bloom-Picnic-Blanket-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1e/Days-of-Bloom-Picnic-Blanket.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Bloom_Picnic_Basket" },
       "order": 3751
     },
     // #endregion
@@ -12688,6 +12778,8 @@
       "type": "Prop",
       "name": "Nature Sonorous Seashell",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/Days-of-Nature-Sonorous-Seashell-icon-Ray.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Days-of-Nature-Sonorous-Seashell.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature#Nature_Sonorous_Seashell" },
       "order": 5701
     },
     // #endregion
@@ -12912,6 +13004,8 @@
       "type": "Prop",
       "name": "Sky Anniversary Pennants",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Icon_prop_days_of_sky_pennants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/68/Days_of_sky_2021_pennants.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#Anniversary_Birthday_Flag" },
       "order": 3901
     },
     {
@@ -13000,6 +13094,8 @@
       "type": "Prop",
       "name": "Sky Anniversary Balloons",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/98/Days-of-Sky-2022-balloon-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/Days-of-Sky-2022-balloon.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#Anniversary_Balloons" },
       "order": 4001
     },
     {
@@ -13007,6 +13103,8 @@
       "type": "Prop",
       "name": "Sky Anniversary Light Fence",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Days-of-Sky-2022-decorative-prop-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/Days-of-Sky-2022-decorative-prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#Anniversary_Light_Fence" },
       "order": 4101
     },
     {
@@ -13014,6 +13112,8 @@
       "type": "Prop",
       "name": "Sky Anniversary Confetti Launcher",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/Days-of-Sky-2022-canon-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/89/Days-of-Sky-2022-confetti-launcher.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#Anniversary_Confetti_Launcher" },
       "order": 4201
     },
     // 2023
@@ -13028,6 +13128,8 @@
       "name": "Oreo Plush",
       "type": "Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4a/Sky-Anniversary-Oreo-prop-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/99/Sky-Anniversary-Oreo-prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#Anniversary_Plush" },
       "order": 5803
     },
     {
@@ -13047,16 +13149,20 @@
     },
     {
       "guid": "9jISGFNSLT",
-      "name": "Sky Anniversary Musical Shell",
+      "name": "Sky Anniversary Sonorous Seashell",
       "type": "Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/18/Sky-Anniversary-Musical-shell-prop-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/ca/Sky-Anniversary-Musical-shell-prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#Anniversary_Sonorous_Seashell" },
       "order": 5801
     },
     {
       "guid": "BQi3QIoOwq",
-      "name": "Sky Anniversary Disco Light",
+      "name": "Sky Anniversary Party Lights",
       "type": "Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/db/Sky-Anniversary-Disco-Light-Prop-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/ce/Sky-Anniversary-Disco-Light-Prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary#Anniversary_Party_Lights" },
       "order": 5802
     },
     // #endregion
@@ -13207,6 +13313,8 @@
       "type": "Prop",
       "name": "Mischief Spooky Dining Set",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e8/Icon_2021_mischief_table.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Prop_2021_mischief_table_open.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Spooky_Dining_Set" },
       "order": 4701
     },
     {
@@ -13232,6 +13340,8 @@
       "type": "Prop",
       "name": "Mischief Pumpkin Prop",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/Icon_2021_mischief_pumpkin_prop.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/45/Days-of-mischief-2021-pumpkin-prop-closeup.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Pumpkin_Prop" },
       "order": 4801
     },
     {
@@ -13302,6 +13412,8 @@
       "type": "Prop",
       "name": "Feline Familiar",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/69/Days-of-Mischief-Cat-Prop-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b8/Days-of-Mischief-Backpack-Cat-Prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Feline_Familiar_Prop" },
       "order": 4901
     },
     // #endregion
@@ -13347,6 +13459,8 @@
       "type": "Prop",
       "name": "Days of Feast Table",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Icon_prop_feast_table.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/2020Feast_Table_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Days_of_Feast_Table" },
       "order": 5001
     },
     {
@@ -13393,6 +13507,8 @@
       "type": "Prop",
       "name": "Winter Feast Pillow",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/Days_of_Feast_Cushion.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/Feast_pillow.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Winter_Feast_Pillow" },
       "order": 5101
     },
     {
@@ -13436,6 +13552,8 @@
       "type": "Prop",
       "name": "Winter Feast Snowglobe",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/Days_of_Feast_Snow_Globe_icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6c/Feast_Snow_globe.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Winter_Feast_Snowglobe" },
       "order": 5201
     },
     {
@@ -13476,6 +13594,8 @@
       "type": "Prop",
       "name": "Snowkid",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/Days-of-Feast-Snowman-Prop-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/Days-of-Feast-Snowman-prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Snowkid_Prop" },
       "order": 5501
     },
     {
@@ -13483,6 +13603,8 @@
       "type": "Prop",
       "name": "Tournament Skyball Set",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/Days-of-Feast-Sky-Ball-Goal-Prop-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/Days-of-Feast-Sky-Ball-Goal-Prop-image.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast#Tournament_Skyball_Set" },
       "order": 5401
     },
     {
@@ -13559,6 +13681,8 @@
       "type": "Prop",
       "name": "Double Deck Chairs",
       "icon": "#double-deck-chairs",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/86/Summer_beach_chairs.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Prop" },
       "order": 4601
     },
     {
@@ -13621,6 +13745,8 @@
       "type": "Prop",
       "name": "Campfire Tent",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Days-of-Sunlight-Tent-Prop-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/49/Days-of-Sunlight-tent-prop.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Campfire_Tent" },
       "order": 3601
     },
     {
@@ -13628,6 +13754,8 @@
       "type": "Prop",
       "name": "Campfire Snack Kit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2e/Days-of-Sunlight-Snack-kit-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/98/Days-of-Sunlight-Campfire-Snack-kit-image.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Campfire_Snack_Kit" },
       "order": 5301
     },
     // #endregion
@@ -13684,7 +13812,10 @@
       "guid": "NEmfcbHb-I",
       "name": "Sunlight Surfboard",
       "type": "Prop",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/Sunlight-Surfboard-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/Sunlight-Surfboard-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/Sunlight-Surfboard.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Surfboard" },
+      "order": 5901
     },
     // #endregion
 

--- a/src/assets/data/items.json
+++ b/src/assets/data/items.json
@@ -4,9 +4,10 @@
     {
       "guid": "EEQZwFIJRs",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Mask05-Diamond.png",
       "name": "Base Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Icon_pants_default.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e5/Legs01-Default.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Outfits#Base_Outfit" },
       "unlocked": true,
       "order": 1
     },
@@ -120,9 +121,10 @@
     {
       "guid": "um3PQEl09a",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bf/Mask09.png",
       "name": "Pointing Candlemaker Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d5/PointingCandlemaker-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/16/Legs07.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pointing_Candlemaker#Outfit" },
       "order": 6
     },
     {
@@ -189,9 +191,10 @@
     {
       "guid": "Vz2Gpg4FSQ",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Mask08.png",
       "name": "Ushering Stargazer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ab/UsheringStargazer-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Legs06.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ushering_Stargazer#Outfit" },
       "order": 7
     },
     {
@@ -328,9 +331,10 @@
     {
       "guid": "1qBmwSZFkz",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a5/Mask11.png",
       "name": "Butterfly Charmer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f3/ButterflyCharmer-4.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f0/Legs08.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Butterfly_Charmer#Outfit" },
       "order": 5
     },
     {
@@ -783,9 +787,10 @@
     {
       "guid": "Y2XIZBa7Ir",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Mask12-Long_Panel.png",
       "name": "Shivering Trailblazer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/32/ShiveringTrailblazer-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Legs03.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Shivering_Trailblazer#Outfit" },
       "order": 2
     },
     {
@@ -951,9 +956,10 @@
     {
       "guid": "bwJ7i7NrlR",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/00/Elder-Mask-Isle-original-Credit-Nastymold.png",
       "name": "Hide'n'Seek Pioneer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/HideNSeekPioneer-4.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e9/Legs_hide_n_seek_pioneer_dress.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Hide%27n%27Seek_Pioneer#Outfit" },
       "order": 9
     },
     // Pouty Porter
@@ -1336,9 +1342,10 @@
     {
       "guid": "N9G6m1vBZh",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Elder-Mask-Prairie-original-Credit-Nastymold.png",
       "name": "Confident Sightseer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/71/ConfidentSightseer-3.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/41/Legs05.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Confident_Sightseer#Outfit" },
       "order": 8
     },
     // Handstanding Thrillseeker
@@ -2258,9 +2265,10 @@
     {
       "guid": "wXOGyF57AN",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Elder-Mask-Forest-original-Credit-Nastymold.png",
       "name": "Memory Whisperer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a1/MemoryWhisperer-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8e/Legs04.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Memory_Whisperer#Outfit" },
       "order": 4
     },
     {
@@ -2318,9 +2326,10 @@
     {
       "guid": "3T-ZS6ZooQ",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Season_of_sanctuary_mask_chill_v2.png",
       "name": "Polite Scholar Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/68/PoliteScholar-2.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Legs02.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Polite_Scholar#Outfit" },
       "order": 3
     },
     {
@@ -3156,10 +3165,11 @@
     {
       "guid": "BD7KBFgGf0",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/Days-of-Feast-Yeti-Goggles.png",
       "group": "Ultimate",
       "name": "Little Prince Ultimate Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Icon_pants_prince_pjs.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ec/Season_of_little_prince_pants3_iap_pj.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/The_Rose#Ultimate_Gifts" },
       "order": 1003
     },
     {
@@ -3173,9 +3183,10 @@
     {
       "guid": "l_C7GM60an",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/89/Days-of-Nature-Glasses.png",
       "name": "Sword Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/Icon_pants_prince_sword.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/79/Season_of_little_prince_pants2_iap_sword.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_The_Little_Prince#Additional_Cosmetics" },
       "order": 1002
     },
     {
@@ -3282,9 +3293,10 @@
     {
       "guid": "SxX0bNDJaR",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/19/Style-Star-Sunglasses.png",
       "name": "Flight Ultimate Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Icon_season_of_flight_pants_1_ult.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Season_of_flight_pants_1_ult.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Flight_Guide#Ultimate_Gifts" },
       "order": 1101
     },
     {
@@ -3744,9 +3756,10 @@
     {
       "guid": "kr95Zsf1Cs",
       "type": "Outfit",
-      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6e/Style-Flame-Sunglasses.png",
       "name": "AURORA Ultimate Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/SoAurora-Ultimate-Outfit-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/SoAurora-Ultimate-Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Ultimate_Gifts" },
       "order": 1502
     },
     {
@@ -3898,6 +3911,8 @@
       "type": "Outfit",
       "name": "Cure for Me Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/49/SoAurora-Additional-Green-Outfit-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/SoAurora-Cure-for-me-Outfit-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Guide#Outfit" },
       "order": 1503
     },
     {
@@ -5288,6 +5303,8 @@
       "type": "Outfit",
       "name": "Boogie Kid Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/76/Mimi-4117_04_boogie_kid_pants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/Belonging_Legs_Isle.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Boogie_Kid#Outfit" },
       "order": 301
     },
     {
@@ -5701,6 +5718,8 @@
       "type": "Outfit",
       "name": "Troupe Greeter Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Mimi-4117_05_troupe_greeter_pants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/31/Season_of_rhythm_pants_isle_welcome_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Greeter#Outfit" },
       "order": 401
     },
     {
@@ -5789,6 +5808,8 @@
       "type": "Outfit",
       "name": "Festival Spin Dancer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/Mimi-4117_05_festive_spin_dancer_pants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/Season_of_rhythm_pants_prairie_dance_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Festival_Spin_Dancer#Outfit" },
       "order": 403
     },
     {
@@ -5877,6 +5898,8 @@
       "type": "Outfit",
       "name": "Admiring Actor Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/16/Mimi-4117_05_admiring_actor_pants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c7/Season_of_rhythm_pants_forest_kisses_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Admiring_Actor#Outfit" },
       "order": 404
     },
     {
@@ -5971,6 +5994,8 @@
       "type": "Outfit",
       "name": "Troupe Juggler Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1b/Mimi-4117_05_troupe_juggler_pants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Season_of_rhythm_pants_valley_juggle_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Troupe_Juggler#Outfit" },
       "order": 402
     },
     {
@@ -6702,6 +6727,8 @@
       "type": "Outfit",
       "name": "Jelly Whisperer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/54/Mimi-4117_07_jelly_whisperer_pants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/Season_of_sanctuary_pants_jelly_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Jelly_Whisperer#Outfit" },
       "order": 601
     },
     {
@@ -6842,6 +6869,8 @@
       "type": "Outfit",
       "name": "Rallying Thrillseeker Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4d/Rallying_trillseeker_pants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/38/Season_of_sanctuary_pants_rally_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Rallying_Thrillseeker#Outfit" },
       "order": 602
     },
     {
@@ -7489,6 +7518,8 @@
       "type": "Outfit",
       "name": "Prophet of Fire Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/01/Mimi-4117_08_prophet_of_fire_pants.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/de/Prophecy-Prophet_of_Fire_Leggings.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Prophet_of_Fire#Outfit" },
       "order": 701
     },
     {
@@ -7584,6 +7615,8 @@
       "type": "Outfit",
       "name": "Bearhug Hermit Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/08/Icon_pants_dreams_bearhug.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/Dreams_pants_bearhug_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Bearhug_Hermit#Outfit" },
       "order": 802
     },
     {
@@ -7728,6 +7761,8 @@
       "type": "Outfit",
       "name": "Peeking Postman Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/Icon_pants_dreams_peeking.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/Dreams_pants_peeking_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Peeking_Postman#Outfit" },
       "order": 801
     },
     {
@@ -8260,6 +8295,8 @@
       "type": "Outfit",
       "name": "Chuckling Scout Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2f/Icon_pants_assembly_ult.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c6/Assembly_pants_chuckling_v2.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Chuckling_Scout#Outfit" },
       "order": 901
     },
     {
@@ -8518,6 +8555,8 @@
       "type": "Outfit",
       "name": "Gloating Narcissist Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3d/Icon_pants_prince_narcissist.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e4/Season_of_little_prince_pants1.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Gloating_Narcissist#Outfit" },
       "order": 1001
     },
     {
@@ -9038,6 +9077,8 @@
       "type": "Outfit",
       "name": "Light Whisperer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9f/Icon_season_of_flight_pants_4_light_whisperer.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Season_of_flight_pants_4_light_whisperer.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Light_Whisperer#Outfit" },
       "order": 1104
     },
     {
@@ -9065,6 +9106,8 @@
       "type": "Outfit",
       "name": "Tinkering Chimesmith Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/81/Icon_season_of_flight_pants_3_tinkering_chimesmith.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Season_of_flight_pants_3_tinkering_chimesmith_gs.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tinkering_Chimesmith#Outfit" },
       "order": 1103
     },
     {
@@ -9186,6 +9229,8 @@
       "type": "Outfit",
       "name": "Talented Builder Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0a/Icon_season_of_flight_pants_2_talented_builder.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/45/Season_of_flight_pants_2_talented_builder_gs.PNG",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Talented_Builder#Outfit" },
       "order": 1102
     },
     {
@@ -9277,6 +9322,8 @@
       "type": "Outfit",
       "name": "Anxious Angler Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/SOAbyss-Anxious-Angler-outfit.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2d/SOAbyss-Anxious-Angler-Cape-outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Anxious_Angler#Outfit" },
       "order": 1201
     },
     {
@@ -9621,6 +9668,8 @@
       "type": "Outfit",
       "name": "Frantic Stagehand Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/SoPerformance_-_Frantic_Stagehand-outfit-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/SoPerformance_-_Frantic_Stagehand-outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Frantic_Stagehand#Outfit" },
       "order": 1302
     },
     {
@@ -9696,6 +9745,8 @@
       "type": "Outfit",
       "name": "Forgetful Storyteller Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/SOPerformance_-Forgetful_Storyteller_-_Outfit-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/76/SOPerformance_-Forgetful_Storyteller_-_Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Forgetful_Storyteller#Outfit" },
       "order": 1303
     },
     {
@@ -9857,6 +9908,8 @@
       "type": "Outfit",
       "name": "Modest Dancer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/SOPerformance-Modest-Dancer-_outfit-icon.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a9/SOPerformance-Modest-Dancer-_Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Modest_Dancer#Outfit" },
       "order": 1301
     },
     {
@@ -9971,6 +10024,8 @@
       "type": "Outfit",
       "name": "Manta Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bd/SOShattering-Light-Outfit-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/SOShattering-Light-Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ancient_Light#Outfit" },
       "order": 1401
     },
     {
@@ -10242,6 +10297,8 @@
       "type": "Outfit",
       "name": "Mindful Miner Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/SoAurora-Mindful-Miner-Outfit-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/SoAurora-Mindful-Miner-Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Mindful_Miner#Outfit" },
       "order": 1501
     },
     {
@@ -10462,6 +10519,8 @@
       "type": "Outfit",
       "name": "AURORA Runaway Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/77/Aurora-Runaway-outfit-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/SoAurora-Purple-Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_AURORA#Runaway_Outfit" },
       "order": 1504
     },
     {
@@ -10469,6 +10528,8 @@
       "type": "Outfit",
       "name": "To The Love Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e9/SoAurora-To-The-Love-Outfit-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ad/SoAurora-To-The-Love-Outfit-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/AURORA_Concert#To_The_Love_Outfit" },
       "order": 1505
     },
     {
@@ -10497,7 +10558,7 @@
       "type": "Shoes",
       "name": "AURORA Musical Voyage Sneakers",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4c/Aurora-Record-Breaker-Sneakers-icon-Credit-Morybel.png",
-      "order": 401
+      "order": 601
     },
     {
       "guid": "T71hdAEX-_",
@@ -10652,6 +10713,8 @@
       "type": "Outfit",
       "name": "Pleading Child Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/SoRemembrance-Pleading-Child-Outfit-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/21/SoRemembrance-Pleading-Child-Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Pleading_Child#Outfit" },
       "order": 1601
     },
     {
@@ -10727,6 +10790,8 @@
       "type": "Outfit",
       "name": "Tiptoeing Tea-Brewer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/SoRemembrance-Tiptoeing-Tea-Brewer-Outfit-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/SoRemembrance-Tiptoeing-Tea-Brewer-Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Tiptoeing_Tea-Brewer#Outfit" },
       "order": 1603
     },
     {
@@ -10774,6 +10839,8 @@
       "type": "Outfit",
       "name": "Wounded Warrior Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/SoRemembrance-Wounded-Warrior-Outfit-Icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/41/SoRemembrance-Wounded-Warrior-Outfit.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Wounded_Warrior#Outfit" },
       "order": 1602
     },
     {
@@ -10864,6 +10931,8 @@
       "type": "Outfit",
       "name": "Oddball Outcast Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/9a/Passage-Oddball-Outcast-outfit-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/Passage-Oddball-Outcast-outfit-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Oddball_Outcast#Outfit" },
       "order": 1702
     },
     {
@@ -11014,6 +11083,8 @@
       "type": "Outfit",
       "name": "Melancholy Mope Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1d/Passage-Melancholy-Mope-Outfit-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8f/Passage-Melancholy-Mope-Outfit-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Melancholy_Mope#Outfit" },
       "order": 1701
     },
     {
@@ -11315,6 +11386,8 @@
       "type": "Outfit",
       "name": "Ascetic Monk Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/Ascetic-Monk-Outfit-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/ca/Ascetic-Monk-Outfit-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Ascetic_Monk#Outfit" },
       "order": 1801
     },
     {
@@ -11368,6 +11441,8 @@
       "type": "Outfit",
       "name": "Nightbird Whisperer Outfit",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/04/Nightbird-Whisperer-Outfit-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/Nightbird-Whisperer-Outfit-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Nightbird_Whisperer#Outfit" },
       "order": 1802
     },
     {
@@ -11481,7 +11556,9 @@
       "type": "Outfit",
       "name": "Days of Fortune Muralist's Smock",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fb/Muralist-Smock-icon-Morybel-0146.png",
-      "order": 10400
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ee/Muralist-Smock-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune#Days_of_Fortune_Muralist's_Smock" },
+      "order": 10100
     },
     {
       "guid": "uzos22Ysp3",
@@ -11755,7 +11832,9 @@
       "type": "Outfit",
       "name": "Bloom Gardening Tunic",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/ba/Days-of-Bloom-Gardener-outfit-icon-Morybel-0146.png",
-      "order": 10100
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1a/Days-of-Bloom-Gardener-outfit-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Bloom_Gardening_Tunic" },
+      "order": 10200
     },
     {
       "guid": "_0PZEyTNxt",
@@ -11975,6 +12054,8 @@
       "type": "Outfit",
       "name": "Rainbow Trousers",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/86/Days-of-Rainbow-2022-pant-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1e/Days_of_Rainbow_2022-Trousers.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Rainbow_Trousers" },
       "order": 10300
     },
     {
@@ -12000,6 +12081,8 @@
       "type": "Outfit",
       "name": "Dark Rainbow Tunic",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a7/Days-of-Color-Dark-Rainbow-Tunic-icon-Morybel-0146.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/87/Days-of-Colors-Dark-Rainbow-Outfit-front.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Rainbow#Dark_Rainbow_Tunic" },
       "order": 10301
     },
     {
@@ -12187,13 +12270,17 @@
       "guid": "E7RAu04_xI",
       "name": "Style Wide-Leg Jeans",
       "type": "Outfit",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/12/Style-Wide-Leg-Jeans-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/12/Style-Wide-Leg-Jeans-icon-Credit-Morybel.png",
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/Style-Wide-Leg-Jeans.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Style#Style_Wide-Leg_Jeans" },
+      "order": 10500
     },
     {
       "guid": "MuQrbnmbdp",
       "name": "Style Bunny Slippers",
       "type": "Shoes",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b4/Style-Bunny-Slippers-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b4/Style-Bunny-Slippers-icon-Credit-Morybel.png",
+      "order": 502
     },
     {
       "guid": "3HeVKqT39a",
@@ -12217,7 +12304,8 @@
       "guid": "d_p_flDgEV",
       "name": "Style Silk Ballet Slippers",
       "type": "Shoes",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/Ballet-Flats-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/Ballet-Flats-icon-Credit-Morybel.png",
+      "order": 501
     },
     {
       "guid": "o4cIshT_hD",
@@ -12331,7 +12419,9 @@
       "type": "Outfit",
       "name": "Mischief Witch Jumper",
       "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/78/Icon_2021_mischief_jumper.png",
-      "order": 10200
+      "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a1/Leggings_2021_mischief_jumper_iap.png",
+      "_wiki": { "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Jumper" },
+      "order": 10400
     },
     {
       "guid": "h-fwwT4T5y",
@@ -12695,7 +12785,8 @@
       "guid": "gsACsrp16_",
       "name": "Sunlight Chunky Sandals",
       "type": "Shoes",
-      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/69/Sunlight-Chunky-Sandals-icon-Credit-Morybel.png"
+      "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/69/Sunlight-Chunky-Sandals-icon-Credit-Morybel.png",
+      "order": 401
     },
     {
       "guid": "NEmfcbHb-I",

--- a/src/styles/flex.less
+++ b/src/styles/flex.less
@@ -7,13 +7,8 @@
 
 .flex-item {
   position: relative;
-  width: var(--item-size);
-  height: var(--item-size);
   background: var(--color-background);
-  border-radius: var(--border-radius)
-}
-
-.flex-item-large {
-  width: var(--item-size-large);
-  height: var(--item-size-large);
+  padding: var(--padding-content);
+  border-radius: var(--border-radius);
+  border: var(--border-solid);
 }

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -306,9 +306,9 @@ mat-icon.seasonal { fill: var(--color-seasonal); }
 .seasonal { color: var(--color-seasonal); fill: var(--color-seasonal); }
 
 .highlight {
-  border: var(--border-highlight);
-  border-radius: var(--border-radius);
-  box-shadow: var(--shadow-highlight);
+  border: var(--border-highlight) !important;
+  border-radius: var(--border-radius) !important;
+  box-shadow: var(--shadow-highlight) !important;
 }
 
 .scroll-x {

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -113,9 +113,31 @@ body { scrollbar-width: thin; }
 }
 ::-webkit-scrollbar-thumb {
   background: var(--color-scroll-thumb);
+  border-radius: 50px;
 }
 ::-webkit-scrollbar-corner {
   background: var(--color-scroll--humb);
+}
+.scroll-hover {
+  &::-webkit-scrollbar {
+    opacity: 0.5;
+    // Make background 50% translucent
+    background: rgba(0, 0, 0, 0.5);
+    // width: 0px;
+    // height: 0px;
+  }
+
+  &::-webkit-scrollbar-track {
+    opacity: 0.5;
+  }
+  &::-webkit-scrollbar-thumb {
+    opacity: 0.5;
+  }
+
+  &:hover::-webkit-scrollbar {
+    width: var(--size);
+    height: var(--size);
+  }
 }
 
 // Bootstrap

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -118,27 +118,6 @@ body { scrollbar-width: thin; }
 ::-webkit-scrollbar-corner {
   background: var(--color-scroll--humb);
 }
-.scroll-hover {
-  &::-webkit-scrollbar {
-    opacity: 0.5;
-    // Make background 50% translucent
-    background: rgba(0, 0, 0, 0.5);
-    // width: 0px;
-    // height: 0px;
-  }
-
-  &::-webkit-scrollbar-track {
-    opacity: 0.5;
-  }
-  &::-webkit-scrollbar-thumb {
-    opacity: 0.5;
-  }
-
-  &:hover::-webkit-scrollbar {
-    width: var(--size);
-    height: var(--size);
-  }
-}
 
 // Bootstrap
 .tooltip-inner {

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -48,7 +48,7 @@
   --background: url('https://silverfeelin.github.io/SkyGame-Planner/assets/game/background.webp');
   --background-filter: blur(4px) brightness(0.8);
 
-  --shadow-highlight: 0px 0px 5px 1px var(--color-highlight);
+  --shadow-highlight: 0px 0px 5px 2px var(--color-highlight);
   --shadow-clock: drop-shadow(1px 1px 1px #000);
 
   --img-preview-height: 160px;


### PR DESCRIPTION
* Add new field guide section to the items page. When opened, shows previews of all items in the selected category. Huge thanks to the Sky wiki contributors and admins for letting me use the images on my site.
* Added wiki links to all item where possible. Replaced the old Preview link with this wiki link.
* Better scrolling to selected item when item details are out of view.
* Change highlight to better show selected item on the default Sky theme.
* Better preserve query parameters on items page.

TODO: 

- [x] Check wiki links of all items. There are likely a few broken links.