### PR TITLE
Favourite items

### DIFF
--- a/src/app/components/children-of-light/children-of-light.component.less
+++ b/src/app/components/children-of-light/children-of-light.component.less
@@ -69,9 +69,3 @@ input.map-input {
   color: var(--color-unlock-check);
   font-weight: bold;
 }
-
-.show-desktop { display: none; }
-@media screen and (min-width: 720px) {
-  .show-desktop { display: unset; }
-  .show-mobile { display: none; }
-}

--- a/src/app/components/items/items.component.html
+++ b/src/app/components/items/items.component.html
@@ -54,19 +54,18 @@
   </div>
 
   <div class="sky-card-body">
-    <div class="container mb" *ngIf="type === 'Emote'">
-      Emotes have a green check mark once you've unlocked all emote levels.
-    </div>
     <div class="sky-flex flex-wrap">
-      <div *ngIf="filterByFav" class="show-only">You have no items favourited in this category</div>
+      <div class="container" *ngIf="filterByFav && !shownIncludesFav">
+        You have no items favourited in this category.
+      </div>
       <ng-container *ngFor="let item of shownItems; let i = index">
         <a class="item-icon" [routerLink]="['/item', item.guid]" [hidden]="filterByFav && !item.favourited">
           <app-item-icon [item]="item" [showSubIcons]="true"
             [class.highlight]="item && item === selectedItem"
-            [class.item-unlocked]="item.unlocked && (item.type !== typeEmote || item.level! >= emoteLevels[item.name])"
+            [class.item-unlocked]="item.unlocked"
             [ngbTooltip]="item.name" container="body" placement="auto" >
           </app-item-icon>
-          <mat-icon class="unlock-check" [class.self]="item.type !== typeEmote || item.level! >= emoteLevels[item.name]" [class.unlocked]="item.unlocked">done</mat-icon>
+          <mat-icon class="unlock-check self" [class.unlocked]="item.unlocked">done</mat-icon>
           <!-- Favourite (bottom left) -->
           <mat-icon *ngIf="item.favourited" class="img-bl">star</mat-icon>
         </a>

--- a/src/app/components/items/items.component.html
+++ b/src/app/components/items/items.component.html
@@ -31,34 +31,36 @@
 </div>
 
 <!-- Items -->
-<div class="sky-card mt" *ngIf="shownItems?.length">
+<div class="sky-card mt" *ngIf="shownItems">
   <div class="sky-card-header">
     <div class="unlock-bar">
-      You have unlocked
-      <b [class.completed]="shownUnlocked == shownItems.length">{{ shownUnlocked }}</b>
-      out of
-      <b [class.completed]="shownUnlocked == shownItems.length">{{ shownItems.length }}</b>
-      items.
-      <div class="none-toggle" [style.opacity]="(shouldShowNone ? 1 : 0.5)" (click)="toggleNone()">
-        <mat-icon svgIcon="none" [ngbTooltip]="'Toggle unequip icon'" container="body" placement="left"></mat-icon>
-      </div>
-      <div class="column-toggle">
-        <mat-icon (click)="setColumns()" [ngbTooltip]="'Toggle column size'" container="body" placement="left">apps</mat-icon>
+      <span class="show-desktop">
+        You have unlocked
+        <b [class.completed]="shownUnlocked == shownCount">{{ shownUnlocked }}</b>
+        out of
+        <b [class.completed]="shownUnlocked == shownCount">{{ shownCount }}</b>
+        items.
+      </span>
+      <span class="show-mobile">
+        <b [class.completed]="shownUnlocked == shownCount">{{ shownUnlocked }}</b>
+        /
+        <b [class.completed]="shownUnlocked == shownCount">{{ shownCount }}</b>
+        unlocked
+      </span>
+      <div class="fav-toggle" [class.toggle-active]="filterByFav" (click)="toggleFav()">
+        <mat-icon [ngbTooltip]="filterByFav ? 'Show all' : 'Show only favourites'" container="body" placement="left">star</mat-icon>
       </div>
     </div>
   </div>
 
   <div class="sky-card-body">
-    <div class="flex item-grid" [class.gap-half-y]="columns">
-      <div class="item-icon" *ngIf="showNone">
-        <div class="item-none">
-          <mat-icon class="" svgIcon="none"></mat-icon>
-        </div>
-        <mat-icon class="unlock-check self unlocked">done</mat-icon>
-      </div>
+    <div class="container mb" *ngIf="type === 'Emote'">
+      Emotes have a green check mark once you've unlocked all emote levels.
+    </div>
+    <div class="sky-flex flex-wrap">
+      <div *ngIf="filterByFav" class="show-only">You have no items favourited in this category</div>
       <ng-container *ngFor="let item of shownItems; let i = index">
-        <div class="item-col-hr" [style.display]="!columns || !i || ((i+offsetNone) % (columns)) ? undefined : 'block'"></div>
-        <a class="item-icon" [routerLink]="['/item', item.guid]">
+        <a class="item-icon" [routerLink]="['/item', item.guid]" [hidden]="filterByFav && !item.favourited">
           <app-item-icon [item]="item" [showSubIcons]="true"
             [class.highlight]="item && item === selectedItem"
             [class.item-unlocked]="item.unlocked && (item.type !== typeEmote || item.level! >= emoteLevels[item.name])"

--- a/src/app/components/items/items.component.less
+++ b/src/app/components/items/items.component.less
@@ -1,34 +1,14 @@
-.item-grid {
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-.item-grid.gap-half-y {
-  row-gap: calc(var(--padding-content) / 2);
-}
-
-.none-toggle {
+.fav-toggle {
   position: absolute;
-  top: 0; right: 24px;
-  width: 24px; height: 24px;
+  top: 0; right: 0;
   cursor: pointer;
   z-index: 2;
   overflow: hidden;
-
-  mat-icon {
-    position: absolute;
-    width: 32px; height: 32px;
-    vertical-align: top;
-    top: -4px; right: -4px;
-  }
 }
-.column-toggle {
-  position: absolute;
-  top: 0;
-  right: 0;
-  cursor: pointer;
-  z-index: 2;
 
-  mat-icon { vertical-align: top; }
+.toggle-active {
+  color: var(--color-favourite);
+  filter: drop-shadow(0px 0px 2px #ffcc00);
 }
 
 .unlock-bar {
@@ -74,24 +54,7 @@
   text-shadow: #000 1px 1px 0;
 }
 
-.item-col-hr {
+.show-only {
   display: none;
-  flex-basis: 100%;
-  height: 0;
-  margin: 0;
-  padding: 0;
-}
-
-.item-none {
-  position: relative;
-  width: var(--item-size);
-  height: var(--item-size);
-  border-radius: var(--border-radius);
-  background: var(--color-unlock-check-background);
-
-  mat-icon {
-    color: var(--color-item);
-    width: 100%;
-    height: 100%;
-  }
+  &:only-child { display: block; }
 }

--- a/src/app/helpers/item-helper.ts
+++ b/src/app/helpers/item-helper.ts
@@ -32,6 +32,9 @@ export class ItemHelper {
   }
 
   static sorter(a: IItem, b: IItem): number {
-    return (a.order || 99999) - (b.order || 99999);
+    const n = (a.order || 99999) - (b.order || 99999);
+    if (n !== 0) { return n; }
+    if (a.level && b.level) { return a.level - b.level; }
+    return a.name.localeCompare(b.name);
   }
 }

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -383,6 +383,8 @@ export class DataService {
     for (const type in ItemType) { types.add(type); }
 
     let shouldWarn = false;
+    const emoteOrders: { [key: string]: number } = {};
+    const emotes: Array<IItem> = [];
     this.itemConfig.items.forEach(item => {
       if (item.id) {
         if (ids.has(item.id)) {
@@ -402,11 +404,18 @@ export class DataService {
         shouldWarn = true;
       }
 
+      if (item.type === 'Emote') {
+        if (item.level === 1) { emoteOrders[item.name] = item.order ?? 999999; }
+        else { emotes.push(item); }
+      }
+
       item.unlocked ||= this._storageService.unlocked.has(item.guid);
       item.favourited = this._storageService.favourites.has(item.guid);
       if (!item.unlocked && item.autoUnlocked) { item.unlocked = true; }
       item.order ??= 999999;
     });
+
+    emotes.forEach(emote => emote.order = emoteOrders[emote.name] ?? emote.order);
 
     shouldWarn && alert('Misconfigured items. Please report this issue.');
   }

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -398,3 +398,11 @@ mat-icon.seasonal { fill: var(--color-seasonal); }
 ngb-tooltip-window {
   z-index: 99999999 !important; // On top of Intro.js highlight.
 }
+
+/* Responsive */
+
+.show-desktop { display: none; }
+@media screen and (min-width: 720px) {
+  .show-desktop { display: unset; }
+  .show-mobile { display: none; }
+}


### PR DESCRIPTION
* Adds a toggle to only show favourited items.
* Removes the "unequip" icon & column toggle.
  * To view a more accurate in-game closet you can use the outfit request tools.
* Show all emote levels to avoid any confusion on which ones are unlocked.

![image](https://github.com/Silverfeelin/SkyGame-Planner/assets/17196309/db5d4c24-d5bb-4b74-85b2-ba6dcf844f05)


Closes #73 