### PR TITLE
[Field Guilde] Return when not viewing image source

### DIFF
--- a/src/app/components/items/item-field-guide/item-field-guide.component.ts
+++ b/src/app/components/items/item-field-guide/item-field-guide.component.ts
@@ -51,6 +51,10 @@ export class ItemFieldGuideComponent {
   }
 
   checkViewSource(url: string) {
+    if (!this.viewingSource) {
+      return;
+    }
+
     if (!url?.startsWith('https://static.wikia.nocookie.net/sky-children-of-the-light')) {
       alert(`Can't view the source since this image is not hosted on the official wiki.`);
       return;


### PR DESCRIPTION
## Bug description
When clicking on an item in the [field guide](https://sky-planner.com/item/field-guide), the wiki page opens up every time.

## Root cause
The bug is caused because it's not checked on the click handler of the anchor element, whether the option to View Source is enabled.

## Solution
Check if the `viewingSource` boolean has been toggled (from the button on the top) when running the `checkViewSource` function of the component.