### PR TITLE
Fix Days of Color Guide spirit name

### DIFF
--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -295,7 +295,7 @@
           "endDate": "2024-07-07",
           "currencyPerDay": 5,
           "spirits": [
-            { "guid": "Db5e396lo0", "spirit": "zS4AGUTIgF", "tree": "3YJalWDFZ7" }
+            { "guid": "Db5e396lo0", "spirit": "L8hK6RLQa_", "tree": "3YJalWDFZ7" }
           ],
           "shops": [
             "B80yCK6Rp4",

--- a/src/assets/data/spirits.json
+++ b/src/assets/data/spirits.json
@@ -1909,6 +1909,14 @@
       "type": "Event",
       "name": "Belonging Ancestor"
     },
+    // #region
+    // Days of Color
+    {
+      "guid": "L8hK6RLQa_",
+      "type": "Event",
+      "name": "Days of Color Guide",
+      "imageUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Days-of-Color-Guide-2024.png"
+    },
     // Firework Festival
     {
       "guid": "NO6tqAn4m3",


### PR DESCRIPTION
## Bug description
The name of the spirit guide for the Days of Color is "Event Staff (IGC)"

## Root cause
The spirit GUID in the JSON file is set to the "Unknown" spirit

## Solution
It is now known the name and looks of the spirit (wiki official image) so we can use that instead in the JSON