### PR TITLE
Currency

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,20 +1,15 @@
 {
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "ng serve",
-      "type": "pwa-chrome",
-      "request": "launch",
-      "preLaunchTask": "npm: start",
-      "url": "http://localhost:4200/"
-    },
-    {
-      "name": "ng test",
       "type": "chrome",
       "request": "launch",
-      "preLaunchTask": "npm: test",
-      "url": "http://localhost:9876/debug.html"
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}"
     }
   ]
 }

--- a/src/app/app-routes.ts
+++ b/src/app/app-routes.ts
@@ -44,6 +44,7 @@ import { ShopNestingComponent } from './components/shops/shop-nesting/shop-nesti
 import { ShopHarmonyHallComponent } from './components/shops/shop-harmony-hall/shop-harmony-hall.component';
 import { ShopEventStoreComponent } from './components/shops/shop-event-store/shop-event-store.component';
 import { ShopOfficeComponent } from './components/shops/shop-office/shop-office.component';
+import { CurrencyComponent } from './components/currency/currency.component';
 
 const title = (title: string) => `${title} - Sky Planner`;
 
@@ -69,6 +70,7 @@ export const routes: Routes = [
           { path: 'blank', component: BlankComponent, title: 'Sky Planner' },
           { path: 'privacy', component: PrivacyComponent },
           { path: 'credits', component: CreditsComponent, title: title('Credits') },
+          { path: 'currency', component: CurrencyComponent, title: title('In-game currency') },
           { path: 'event', component: EventsComponent, title: title('Events') },
           { path: 'event-calculator', component: EventCalculatorComponent, title: title('Event Calculator') },
           { path: 'event/:guid', component: EventComponent },

--- a/src/app/components/currency/currency.component.html
+++ b/src/app/components/currency/currency.component.html
@@ -20,9 +20,8 @@
     <div class="sky-card-body">
       <div class="container">
         <p>
-          You had leftover season currency from the previous season. These have been converted into regular currencies.<br/>
-          Candles: +{{ converted.candles }}<br/>
-          Hearts: +{{ converted.hearts }}
+          You had leftover season candles from the previous season. These have been converted into regular currencies.<br/>
+          <b class="c-new">+ {{ converted.candles }}</b>
         </p>
         <button type="button" (click)="converted=undefined">Dismiss</button>
       </div>
@@ -31,7 +30,7 @@
 }
 
 <div class="mt">
-  <app-card [title]="'Regular currency'" [foldable]="true" [folded]="false">
+  <app-card [title]="'Regular currency'" [foldable]="false">
     <div class="container">
       <div>
         <mat-icon [svgIcon]="'candle'" class="v-middle" [ngbTooltip]="'Candles'" container="body"></mat-icon>&nbsp;x&nbsp;
@@ -55,7 +54,7 @@
 
 @if (ongoingSeason) {
   <div class="mt">
-    <app-card [title]="'Seasonal currency'" [foldable]="true" [folded]="false">
+    <app-card [title]="'Seasonal currency'" [foldable]="false">
       <div class="container">
         <div class="mb">
           @if (ongoingSeason.iconUrl) {
@@ -69,12 +68,6 @@
             [value]="currencies.seasonCurrencies[ongoingSeason.guid].candles"
             (blur)="onCurrencyInputBlur($event)" (input)="onCurrencyInput()"/>
         </div>
-        <div>
-          <mat-icon [svgIcon]="'heart'" class="v-middle seasonal" [ngbTooltip]="'Season hearts'"></mat-icon>&nbsp;x&nbsp;
-          <input #inpSh type="number" min="0" max="99999" class="d-inline-block input-no-arrows" style="width: 64px;"
-            [value]="currencies.seasonCurrencies[ongoingSeason.guid].hearts"
-            (blur)="onCurrencyInputBlur($event)" (input)="onCurrencyInput()"/>
-        </div>
       </div>
     </app-card>
   </div>
@@ -82,7 +75,7 @@
 
 @if (ongoingEventInstances.length) {
   <div class="mt">
-    <app-card [title]="'Event currency'" [foldable]="true" [folded]="false">
+    <app-card [title]="'Event currency'" [foldable]="false">
       <div class="sky-flex flex-wrap flex-column">
         @for (instance of ongoingEventInstances; track instance.guid) {
           <div class="container">
@@ -92,7 +85,7 @@
             <div>
               <mat-icon [svgIcon]="'ticket'" class="v-middle" [ngbTooltip]="'Event currency'"></mat-icon>&nbsp;x&nbsp;
               <input #inpEc type="number" min="0" max="99999" class="d-inline-block input-no-arrows" style="width: 64px;"
-                [value]="currencies.eventCurrencies[instance.guid]"
+                [value]="currencies.eventCurrencies[instance.guid].tickets"
                 (blur)="onCurrencyInputBlur($event)" (input)="onCurrencyInput()"/>
             </div>
           </div>

--- a/src/app/components/currency/currency.component.html
+++ b/src/app/components/currency/currency.component.html
@@ -5,8 +5,8 @@
   <div class="sky-card-body">
     <div class="container">
       <p>
-        On this page you can keep track of your in-game currencies.
-        Some actions, such as checking in your daily tasks, will automatically update these numbers.
+        On this page you can keep track of your in-game currencies.<br/>
+        These currencies will automatically change when unlocking items on the website, checking in your dailies and while using the calculator.
       </p>
     </div>
   </div>
@@ -101,4 +101,3 @@
     </app-card>
   </div>
 }
-

--- a/src/app/components/currency/currency.component.html
+++ b/src/app/components/currency/currency.component.html
@@ -1,0 +1,104 @@
+<div class="sky-card">
+  <div class="sky-card-header">
+    <h1 class="h2 mb-0">In-game currency</h1>
+  </div>
+  <div class="sky-card-body">
+    <div class="container">
+      <p>
+        On this page you can keep track of your in-game currencies.
+        Some actions, such as checking in your daily tasks, will automatically update these numbers.
+      </p>
+    </div>
+  </div>
+</div>
+
+@if (converted) {
+  <div class="sky-card mt">
+    <div class="sky-card-header">
+      <h1 class="h2 mb-0">Converted currencies</h1>
+    </div>
+    <div class="sky-card-body">
+      <div class="container">
+        <p>
+          You had leftover season currency from the previous season. These have been converted into regular currencies.<br/>
+          Candles: +{{ converted.candles }}<br/>
+          Hearts: +{{ converted.hearts }}
+        </p>
+        <button type="button" (click)="converted=undefined">Dismiss</button>
+      </div>
+    </div>
+  </div>
+}
+
+<div class="mt">
+  <app-card [title]="'Regular currency'" [foldable]="true" [folded]="false">
+    <div class="container">
+      <div>
+        <mat-icon [svgIcon]="'candle'" class="v-middle" [ngbTooltip]="'Candles'" container="body"></mat-icon>&nbsp;x&nbsp;
+        <input #inpC (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="currencies.candles" class="d-inline-block input-no-arrows" style="width: 64px;"/>
+      </div>
+      <div>
+        <mat-icon [svgIcon]="'heart'" class="v-middle" [ngbTooltip]="'Hearts'" container="body"></mat-icon>&nbsp;x&nbsp;
+        <input #inpH (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="currencies.hearts" class="d-inline-block input-no-arrows" style="width: 64px;"/>
+      </div>
+      <div>
+        <mat-icon [svgIcon]="'ascended-candle'" class="v-middle" [ngbTooltip]="'Ascended candles'" container="body"></mat-icon>&nbsp;x&nbsp;
+        <input #inpAc (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="currencies.ascendedCandles" class="d-inline-block input-no-arrows" style="width: 64px;"/>
+      </div>
+      <div>
+        <mat-icon [svgIcon]="'gift'" class="v-middle seasonal" [ngbTooltip]="'Gift season passes'" container="body"></mat-icon>&nbsp;x&nbsp;
+        <input #inpSp (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="currencies.giftPasses" class="d-inline-block input-no-arrows" style="width: 64px;"/>
+      </div>
+    </div>
+  </app-card>
+</div>
+
+@if (ongoingSeason) {
+  <div class="mt">
+    <app-card [title]="'Seasonal currency'" [foldable]="true" [folded]="false">
+      <div class="container">
+        <div class="mb">
+          @if (ongoingSeason.iconUrl) {
+            <img [src]="ongoingSeason.iconUrl" class="icon">
+          }
+          <b>{{ ongoingSeason.name}}</b>
+        </div>
+        <div>
+          <mat-icon [svgIcon]="'candle'" class="v-middle seasonal" [ngbTooltip]="'Season candles'"></mat-icon>&nbsp;x&nbsp;
+          <input #inpSc type="number" min="0" max="99999" class="d-inline-block input-no-arrows" style="width: 64px;"
+            [value]="currencies.seasonCurrencies[ongoingSeason.guid].candles"
+            (blur)="onCurrencyInputBlur($event)" (input)="onCurrencyInput()"/>
+        </div>
+        <div>
+          <mat-icon [svgIcon]="'heart'" class="v-middle seasonal" [ngbTooltip]="'Season hearts'"></mat-icon>&nbsp;x&nbsp;
+          <input #inpSh type="number" min="0" max="99999" class="d-inline-block input-no-arrows" style="width: 64px;"
+            [value]="currencies.seasonCurrencies[ongoingSeason.guid].hearts"
+            (blur)="onCurrencyInputBlur($event)" (input)="onCurrencyInput()"/>
+        </div>
+      </div>
+    </app-card>
+  </div>
+}
+
+@if (ongoingEventInstances.length) {
+  <div class="mt">
+    <app-card [title]="'Event currency'" [foldable]="true" [folded]="false">
+      <div class="sky-flex flex-wrap flex-column">
+        @for (instance of ongoingEventInstances; track instance.guid) {
+          <div class="container">
+            <div class="mb">
+              <b>{{ instance.name ?? instance.event.name }}</b>
+            </div>
+            <div>
+              <mat-icon [svgIcon]="'ticket'" class="v-middle" [ngbTooltip]="'Event currency'"></mat-icon>&nbsp;x&nbsp;
+              <input #inpEc type="number" min="0" max="99999" class="d-inline-block input-no-arrows" style="width: 64px;"
+                [value]="currencies.eventCurrencies[instance.guid]"
+                (blur)="onCurrencyInputBlur($event)" (input)="onCurrencyInput()"/>
+            </div>
+          </div>
+        }
+      </div>
+    </app-card>
+  </div>
+}
+

--- a/src/app/components/currency/currency.component.html
+++ b/src/app/components/currency/currency.component.html
@@ -21,6 +21,7 @@
       <div class="container">
         <p>
           You had leftover season candles from the previous season. These have been converted into regular currencies.<br/>
+          <mat-icon [svgIcon]="'candle'" class="v-middle"></mat-icon>
           <b class="c-new">+ {{ converted.candles }}</b>
         </p>
         <button type="button" (click)="converted=undefined">Dismiss</button>

--- a/src/app/components/currency/currency.component.html
+++ b/src/app/components/currency/currency.component.html
@@ -55,7 +55,7 @@
 
 @if (ongoingSeason) {
   <div class="mt">
-    <app-card [title]="'Seasonal currency'" [foldable]="false">
+    <app-card [title]="'Season currency'" [foldable]="false">
       <div class="container">
         <div class="mb">
           @if (ongoingSeason.iconUrl) {

--- a/src/app/components/currency/currency.component.html
+++ b/src/app/components/currency/currency.component.html
@@ -6,7 +6,7 @@
     <div class="container">
       <p>
         On this page you can keep track of your in-game currencies.<br/>
-        These currencies will automatically change when unlocking items on the website, checking in your dailies and while using the calculator.
+        These currencies will automatically change when unlocking items, checking in your dailies and while using the calculator.
       </p>
     </div>
   </div>

--- a/src/app/components/currency/currency.component.ts
+++ b/src/app/components/currency/currency.component.ts
@@ -1,0 +1,140 @@
+import { ChangeDetectionStrategy, Component, ElementRef, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { CardComponent } from "../layout/card/card.component";
+import { MatIcon } from '@angular/material/icon';
+import { StorageService } from '@app/services/storage.service';
+import { IStorageCurrencies } from '@app/services/storage/storage-provider.interface';
+import { ISeason } from '@app/interfaces/season.interface';
+import { IEventInstance } from '@app/interfaces/event.interface';
+import { DataService } from '@app/services/data.service';
+import { DateHelper } from '@app/helpers/date-helper';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'app-currency',
+  standalone: true,
+  imports: [CardComponent, MatIcon, NgbTooltip],
+  templateUrl: './currency.component.html',
+  styleUrl: './currency.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CurrencyComponent {
+  @ViewChild('inpC', { static: true }) inpC!: ElementRef<HTMLInputElement>;
+  @ViewChild('inpH', { static: true }) inpH!: ElementRef<HTMLInputElement>;
+  @ViewChild('inpAc', { static: true }) inpAc!: ElementRef<HTMLInputElement>;
+  @ViewChild('inpSp', { static: false }) inpSp!: ElementRef<HTMLInputElement>;
+  @ViewChild('inpSc', { static: false }) inpSc!: ElementRef<HTMLInputElement>;
+  @ViewChild('inpSh', { static: false }) inpSh!: ElementRef<HTMLInputElement>;
+  @ViewChildren('inpEc') inpEc!: QueryList<ElementRef<HTMLInputElement>>;
+
+  currencies: IStorageCurrencies;
+  ongoingSeason?: ISeason;
+  ongoingEventInstances: Array<IEventInstance>;
+
+  converted?: { candles: number; hearts: number; };
+
+  constructor(
+    private readonly _dataService: DataService,
+    private readonly _storageService: StorageService
+  ) {
+    this.currencies = _storageService.getCurrencies();
+    let changed = false;
+
+    this.ongoingSeason = DateHelper.getActive(this._dataService.seasonConfig.items);
+    if (this.ongoingSeason) {
+      this.currencies.seasonCurrencies[this.ongoingSeason.guid] ??= { candles: 0, hearts: 0 };
+    }
+
+    const ongoingEventGuids = new Set<string>();
+    this.ongoingEventInstances = [];
+    for (const event of this._dataService.eventConfig.items) {
+      if (!event.instances) { continue; }
+      const eventDates = DateHelper.groupByPeriod(event.instances);
+      if (!eventDates.active.length) { continue; }
+      const instance = eventDates.active.at(-1)!;
+      this.ongoingEventInstances.push(instance);
+      ongoingEventGuids.add(instance.guid);
+
+      this.currencies.eventCurrencies[instance.guid] ??= 0;
+    }
+
+    // Convert old season currency. This might be better suited to run on site load.
+    for (const key of Object.keys(this.currencies.seasonCurrencies)) {
+      if (key === this.ongoingSeason?.guid) { continue; }
+      const value = this.currencies.seasonCurrencies[key];
+      this.currencies.candles += value.candles;
+      this.currencies.hearts += value.hearts;
+      delete this.currencies.seasonCurrencies[key];
+
+      this.converted = { candles: value.candles, hearts: value.hearts };
+      changed = true;
+    }
+
+    // Remove old event currencies.
+    for (const key of Object.keys(this.currencies.eventCurrencies)) {
+      if (ongoingEventGuids.has(key)) { continue; }
+      delete this.currencies.eventCurrencies[key];
+      changed = true;
+    }
+
+    // Save converted and removed currencies.
+    if (changed) {
+      this._storageService.setCurrencies(this.currencies);
+    }
+  }
+
+  onCurrencyInput(): void {
+    this.currencyInputChanged();
+  }
+
+  onCurrencyInputBlur(evt: Event): void {
+    const target = evt.target as HTMLInputElement;
+    const value = parseInt(target.value, 10) || 0;
+    if (value <= 0) {
+      target.value = '0';
+    } else if (value > 99999) {
+      target.value = '99999';
+    } else if (!value) {
+      target.value = '';
+    }
+
+    this.currencyInputChanged();
+  }
+
+  currencyInputChanged(): void {
+    // Candles
+    const targetC = this.inpC.nativeElement;
+    this.currencies.candles = Math.min(99999, Math.max(parseInt(targetC.value, 10) || 0, 0));
+    // Hearts
+    const targetH = this.inpH.nativeElement;
+    this.currencies.hearts = Math.min(99999, Math.max(parseInt(targetH.value, 10) || 0, 0));
+    // Ascended candles
+    const targetAc = this.inpAc.nativeElement;
+    this.currencies.ascendedCandles = Math.min(99999, Math.max(parseInt(targetAc.value, 10) || 0, 0));
+    // Gift passes
+    const targetSp = this.inpSp.nativeElement;
+    this.currencies.giftPasses = Math.min(99999, Math.max(parseInt(targetSp.value, 10) || 0, 0));
+
+    if (this.ongoingSeason) {
+      // Season candles
+      if (this.inpSc) {
+        const targetSc = this.inpSc.nativeElement;
+        this.currencies.seasonCurrencies[this.ongoingSeason.guid].candles = Math.min(99999, Math.max(parseInt(targetSc.value, 10) || 0, 0));
+      }
+      // Season hearts
+      if (this.inpSh) {
+        const targetSh = this.inpSh.nativeElement;
+        this.currencies.seasonCurrencies[this.ongoingSeason.guid].hearts = Math.min(99999, Math.max(parseInt(targetSh.value, 10) || 0, 0));
+      }
+    }
+
+    const inpsEc = this.inpEc.toArray();
+    if (inpsEc.length) {
+      for (const [i, instance] of this.ongoingEventInstances.entries()) {
+        const targetEc = inpsEc[i].nativeElement;
+        this.currencies.eventCurrencies[instance.guid] = Math.min(99999, Math.max(parseInt(targetEc.value, 10) || 0, 0));
+      }
+    }
+
+    this._storageService.setCurrencies(this.currencies);
+  }
+}

--- a/src/app/components/event-card/event-card.component.html
+++ b/src/app/components/event-card/event-card.component.html
@@ -52,7 +52,7 @@
         </div>
       }
       <!-- Check-in -->
-      <div *ngIf="sections['checkin']" (click)="checkin()"
+      <div *ngIf="sections['checkin']" (click)="checkin($event)"
         class="item checkin" [class.active]="checkedIn" [style.order]="sections['checkin']"
       >
         <mat-icon class="menu-icon">{{checkedIn ? 'check_box' : 'check_box_outline_blank'}}</mat-icon>

--- a/src/app/components/event-card/event-card.component.ts
+++ b/src/app/components/event-card/event-card.component.ts
@@ -15,6 +15,7 @@ import { DateComponent } from '../util/date/date.component';
 import { MatIcon } from '@angular/material/icon';
 import { NgIf } from '@angular/common';
 import { DiscordLinkComponent } from "../util/discord-link/discord-link.component";
+import { CurrencyService } from '@app/services/currency.service';
 
 type Section = 'img' | 'date' | 'overview' | 'list' | 'recent' | 'upcoming' | 'cost' | 'dailies' | 'checkin' | 'calculator';
 export interface EventCardOptions {
@@ -45,6 +46,7 @@ export class EventCardComponent implements OnInit, OnChanges, OnDestroy {
   _subs = new SubscriptionBag();
 
   constructor(
+    private readonly _currencyService: CurrencyService,
     private readonly _eventService: EventService,
     private readonly _changeDetectorRef: ChangeDetectorRef
   ) {
@@ -69,12 +71,19 @@ export class EventCardComponent implements OnInit, OnChanges, OnDestroy {
     this._subs.unsubscribe();
   }
 
-  checkin(): void {
+  checkin(evt: MouseEvent): void {
     this.checkedIn = !this.checkedIn;
     if (this.checkedIn) {
-      localStorage.setItem(`event.checkin.${this.event?.guid}`, DateTime.local({ zone: DateHelper.skyTimeZone }).toFormat('yyyy-MM-dd'));
+      localStorage.setItem(`event.checkin.${this.event!.guid}`, DateTime.local({ zone: DateHelper.skyTimeZone }).toFormat('yyyy-MM-dd'));
     } else {
-      localStorage.removeItem(`event.checkin.${this.event?.guid}`);
+      localStorage.removeItem(`event.checkin.${this.event!.guid}`);
+    }
+
+    let dailyCurrency = this.instance?.calculatorData?.dailyCurrencyAmount || 0;
+    if (dailyCurrency) {
+      if (!this.checkedIn) { dailyCurrency = -dailyCurrency; }
+      this._currencyService.addEventCurrency(this.instance!.guid, dailyCurrency);
+      this._currencyService.animateCurrencyGained(evt, dailyCurrency);
     }
   }
 

--- a/src/app/components/event/event-calculator/event-calculator.component.html
+++ b/src/app/components/event/event-calculator/event-calculator.component.html
@@ -27,11 +27,6 @@
         <mat-icon class="menu-icon">arrow_back</mat-icon>
         <span class="menu-label">Go to Event</span>
       </a>
-      <div class="container mt">
-        <mat-icon class="result-warn">priority_high</mat-icon>
-        This calculator has been reworked because of the new event currency for the Tournament of Triumph event.<br/>
-        Please let me know if you encounter any issues! You can ping me in the Sky Discord: &#64;Silverfeelin
-      </div>
       @if (concluded) {
         <div class="container mt">
           <mat-icon class="result-warn">priority_high</mat-icon>
@@ -44,7 +39,7 @@
         <div>
           Your current event currency:
           <mat-icon [svgIcon]="'ticket'" class="v-middle"></mat-icon>
-          <input #inpEc (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="999" (input)="onCurrencyInput()" [value]="currencyCount" class="d-inline-block input-sc input-no-arrows" style="width: 64px;"/>
+          <input #inpEc (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="currencyCount" class="d-inline-block input-sc input-no-arrows" style="width: 64px;"/>
           <button type="button" class="button-sc button-sc" (click)="addCurrency()">+{{currencyPerDay}} (daily)</button>
         </div>
         <div>
@@ -57,12 +52,12 @@
         <div>
           Your current candles:
           <mat-icon [svgIcon]="'candle'" class="v-middle"></mat-icon>
-          <input #inpC (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="999" (input)="onCurrencyInput()" [value]="candleCount" class="d-inline-block input-no-arrows" style="width: 64px;"/>
+          <input #inpC (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="candleCount" class="d-inline-block input-no-arrows" style="width: 64px;"/>
         </div>
         <div>
           Your current hearts:
           <mat-icon [svgIcon]="'heart'" class="v-middle"></mat-icon>
-          <input #inpH (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="999" (input)="onCurrencyInput()" [value]="heartCount" class="d-inline-block input-no-arrows" style="width: 64px;"/>
+          <input #inpH (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="heartCount" class="d-inline-block input-no-arrows" style="width: 64px;"/>
         </div>
 
         @if (timedCurrencies.length) {
@@ -92,7 +87,7 @@
                   you can get <b>{{ timedCurrency.amount}}</b> extra event currency.<br/>
                   Please enter how much you have collected so far:
                 }
-                <input #inpTimed [attr.data-guid]="timedCurrency.guid" (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="999" (input)="onCurrencyInput()" [value]="timedCurrencyCount[timedCurrency.guid]" class="d-inline-block input-no-arrows" style="width: 64px;"/>
+                <input #inpTimed [attr.data-guid]="timedCurrency.guid" (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="timedCurrencyCount[timedCurrency.guid]" class="d-inline-block input-no-arrows" style="width: 64px;"/>
               </div>
             }
           </div>

--- a/src/app/components/event/event-calculator/event-calculator.component.ts
+++ b/src/app/components/event/event-calculator/event-calculator.component.ts
@@ -325,8 +325,8 @@ export class EventCalculatorComponent {
 
     this.includesToday = parsed.it === today;
     const currencies = this._storageService.getCurrencies();
-    const eventCurrency = currencies.eventCurrencies?.[this.eventInstance.guid] || 0;
-    this.currencyCount = eventCurrency;
+    const eventCurrency = currencies.eventCurrencies?.[this.eventInstance.guid] || { tickets: 0 };
+    this.currencyCount = eventCurrency.tickets;
     this.candleCount = currencies.candles;
     this.heartCount = currencies.hearts;
 

--- a/src/app/components/icon/icon.component.html
+++ b/src/app/components/icon/icon.component.html
@@ -2,7 +2,14 @@
   <div class="img img-bg" *ngIf="isStoryBlok" [style.background-image]="'url(\''+src+'\')'">
 
   </div>
-  <img class="img" *ngIf="!isSvg && !isStoryBlok" [src]="safeString || safeUrl" crossorigin="anonymous"
-    [style.width]="width" [style.height]="height" [attr.loading]="lazy ? 'lazy' : undefined" [attr.draggable]="draggable">
-  <mat-icon *ngIf="isSvg && safeString" [svgIcon]="safeString"></mat-icon>
+  @if (!isSvg && !isStoryBlok) {
+    <img class="img" [src]="safeString || safeUrl" crossorigin="anonymous"
+      [style.width]="width" [style.height]="height" [style.verticalAlign]="verticalAlign"
+      [attr.loading]="lazy ? 'lazy' : undefined" [attr.draggable]="draggable">
+  }
+  @if (isSvg && safeString) {
+    <mat-icon [svgIcon]="safeString"
+      [style.width]="width" [style.height]="height" [style.verticalAlign]="verticalAlign">
+    </mat-icon>
+  }
 </ng-container>

--- a/src/app/components/icon/icon.component.ts
+++ b/src/app/components/icon/icon.component.ts
@@ -21,6 +21,7 @@ export class IconComponent implements OnChanges {
 
   @Input() width?: string;
   @Input() height?: string;
+  @Input() verticalAlign?: string;
 
   @Input() lazy?: boolean;
   @Input() draggable?: boolean;

--- a/src/app/components/menu/menu.component.html
+++ b/src/app/components/menu/menu.component.html
@@ -16,6 +16,11 @@
         <span class="name header">Sky Planner</span>
       </a>
       <hr/>
+      <!-- Currency -->
+      <a class="item" [routerLink]="'currency'" routerLinkActive="menu-active" [ngbTooltip]="wide ? '' : 'Currency'" placement="right" container="body">
+        <app-icon [src]="'#candle'" [width]="'24px'" [height]="'24px'" [verticalAlign]="'top'"></app-icon>
+        <span class="name">Currency</span>
+      </a>
       <!-- Items -->
       <a class="item" [routerLink]="'item'" routerLinkActive="menu-active" [ngbTooltip]="wide ? '' : 'Items'" placement="right" container="body">
         <mat-icon>checkroom</mat-icon>

--- a/src/app/components/menu/menu.component.ts
+++ b/src/app/components/menu/menu.component.ts
@@ -6,13 +6,14 @@ import { EventService } from 'src/app/services/event.service';
 import { MatIcon } from '@angular/material/icon';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { NgIf } from '@angular/common';
+import { IconComponent } from "../icon/icon.component";
 
 @Component({
     selector: 'app-menu',
     templateUrl: './menu.component.html',
     styleUrls: ['./menu.component.less'],
     standalone: true,
-    imports: [NgIf, NgbTooltip, MatIcon, RouterLinkActive, RouterLink]
+    imports: [NgIf, NgbTooltip, MatIcon, RouterLinkActive, RouterLink, IconComponent]
 })
 export class MenuComponent {
   wide = false;

--- a/src/app/components/node/node.component.ts
+++ b/src/app/components/node/node.component.ts
@@ -14,6 +14,7 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { NgIf } from '@angular/common';
 import { CostHelper } from '@app/helpers/cost-helper';
 import { CurrencyService } from '@app/services/currency.service';
+import { DateHelper } from '@app/helpers/date-helper';
 
 export type NodeAction = 'unlock' | 'find' | 'favourite';
 

--- a/src/app/components/season-card/season-card.component.html
+++ b/src/app/components/season-card/season-card.component.html
@@ -50,7 +50,7 @@
       </div>
     }
     <!-- Check-in -->
-    <div *ngIf="sections['checkin']" (click)="checkin()"
+    <div *ngIf="sections['checkin']" (click)="checkin($event)"
       class="item checkin" [class.active]="checkedIn" [style.order]="sections['checkin']"
     >
       <mat-icon class="menu-icon">{{checkedIn ? 'check_box' : 'check_box_outline_blank'}}</mat-icon>

--- a/src/app/components/season-card/season-card.component.ts
+++ b/src/app/components/season-card/season-card.component.ts
@@ -92,7 +92,7 @@ export class SeasonCardComponent implements OnInit, OnChanges, OnDestroy {
 
     let dailyCurrency = this._storageService.hasSeasonPass(this.season!.guid) ? 6 : 5;
     if (!this.checkedIn) { dailyCurrency = -dailyCurrency; }
-    this._currencyService.addSeasonCurrency(this.season!.guid, dailyCurrency, 0);
+    this._currencyService.addSeasonCurrency(this.season!.guid, dailyCurrency);
     this._currencyService.animateCurrencyGained(evt, dailyCurrency);
   }
 

--- a/src/app/components/season/season-calculator/season-calculator.component.html
+++ b/src/app/components/season/season-calculator/season-calculator.component.html
@@ -36,8 +36,8 @@
         <div>
           Your season candles:
           <mat-icon [svgIcon]="'candle'" class="seasonal v-middle"></mat-icon>
-          <input #inpSc (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="999" (input)="onCurrencyInput()" [value]="candleCount" class="d-inline-block input-sc input-no-arrows" style="width: 64px;"/>
-          <button type="button" class="button-sc" (click)="addCurrency()">+{{hasSeasonPass ? '6' : '5'}}&nbsp;</button>
+          <input #inpSc (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="99999" (input)="onCurrencyInput()" [value]="candleCount" class="d-inline-block input-sc input-no-arrows" style="width: 64px;"/>
+          <button type="button" class="button-sc" (click)="addCurrency()">+{{hasSeasonPass ? '6' : '5'}} (daily)</button>
         </div>
         <div>
           Today's candles:

--- a/src/app/components/season/season-calculator/season-calculator.component.html
+++ b/src/app/components/season/season-calculator/season-calculator.component.html
@@ -27,23 +27,23 @@
       <div class="container mt sky-flex flex-cols flex-align-start gap-half">
         <b>Settings</b>
         <div>
+          Season Pass:
+          <button type="button" (click)="toggleSeasonPass()">
+            <mat-icon class="calc-button-icon">{{ hasSeasonPass ? 'check' : 'close' }}</mat-icon>
+            <span class="calc-button-label">{{ hasSeasonPass ? 'owned' : 'not owned' }}</span>
+          </button>
+        </div>
+        <div>
           Your season candles:
+          <mat-icon [svgIcon]="'candle'" class="seasonal v-middle"></mat-icon>
           <input #inpSc (blur)="onCurrencyInputBlur($event)" type="number" min="0" max="999" (input)="onCurrencyInput()" [value]="candleCount" class="d-inline-block input-sc input-no-arrows" style="width: 64px;"/>
-          <button type="button" class="button-sc button-sc-1" (click)="addCurrency(1)">+1</button>
-          <button type="button" class="button-sc button-sc-5" (click)="addCurrency(5)">+5</button>
+          <button type="button" class="button-sc" (click)="addCurrency()">+{{hasSeasonPass ? '6' : '5'}}&nbsp;</button>
         </div>
         <div>
           Today's candles:
           <button type="button" (click)="toggleIncludesToday()">
             <mat-icon class="calc-button-icon">{{ includesToday ? 'check' : 'close' }}</mat-icon>
             <span class="calc-button-label">{{ includesToday ? 'obtained' : 'not obtained' }}</span>
-          </button>
-        </div>
-        <div>
-          Season Pass:
-          <button type="button" (click)="toggleSeasonPass()">
-            <mat-icon class="calc-button-icon">{{ haveSeasonPass ? 'check' : 'close' }}</mat-icon>
-            <span class="calc-button-label">{{ haveSeasonPass ? 'owned' : 'not owned' }}</span>
           </button>
         </div>
         <div>
@@ -75,7 +75,7 @@
             Required items leading up to the items you want are included in the calculations!
           </blockquote>
         }
-        @if (!haveSeasonPass && hasSeasonPassNode) {
+        @if (!hasSeasonPass && hasSeasonPassNode) {
           <blockquote class="mb-0">
             <mat-icon class="result-warn">priority_high</mat-icon>
             You have selected items that require the <b class="c-old">Season Pass</b>!
@@ -88,12 +88,12 @@
         </div>
         <div>
           Because you
-          <b [class.c-new]="haveSeasonPass" [class.c-old]="!haveSeasonPass">
-            {{ haveSeasonPass ? 'own' : 'do not own' }}
+          <b [class.c-new]="hasSeasonPass" [class.c-old]="!hasSeasonPass">
+            {{ hasSeasonPass ? 'own' : 'do not own' }}
           </b>
           the Season Pass,
           you will be able to get
-          <b class="c-new">{{ haveSeasonPass ? '6' : '5' }}</b>
+          <b class="c-new">{{ hasSeasonPass ? '6' : '5' }}</b>
           season candles every day, not including bonus events.
         </div>
         <div>
@@ -166,7 +166,7 @@
 <ng-template #tNode let-node>
   <div class="node-show-hover"
     [class.node-have]="node.item?.unlocked" [class.node-want]="wantNodes[node.guid]"
-    [class.node-sp]="node.item?.group === 'SeasonPass' && !haveSeasonPass"
+    [class.node-sp]="node.item?.group === 'SeasonPass' && !hasSeasonPass"
     (click)="toggleButtons(node)"
   >
     <div class="node-overlay" [class.o-1]="nodeShowButtons === node"

--- a/src/app/components/season/season-calculator/season-calculator.component.less
+++ b/src/app/components/season/season-calculator/season-calculator.component.less
@@ -1,16 +1,13 @@
 .button-sc {
   padding-left: 2px;
   padding-right: 2px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .input-sc {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
-}
-.button-sc-1 { border-radius: 0; }
-.button-sc-5 {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
 }
 .tree-scroll {
   padding-bottom: 4px;

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -102,12 +102,14 @@ export class SettingsComponent {
         version: '0.1.1',
         storageData: {
           date: '2024-04-01T00:00:00.000+00:00',
+          currencies: { candles: 0, hearts: 0, ascendedCandles: 0, giftPasses: 0, eventCurrencies: {}, seasonCurrencies: {} },
           unlocked: d.unlocked,
           wingedLights: d.wingedLights,
           favourites: d.favourites,
           seasonPasses: '',
           mapMarkers: '',
-          keys: {}},
+          keys: {}
+        },
         closetData: d.closet
       };
     }
@@ -158,6 +160,7 @@ export class SettingsComponent {
 
     this._storageService.import({
       date: DateTime.now().toISO()!,
+      currencies: { candles: 0, hearts: 0, ascendedCandles: 0, giftPasses: 0, eventCurrencies: {}, seasonCurrencies: {} },
       unlocked: '',
       wingedLights: '',
       favourites: '',

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -46,6 +46,7 @@ export class SettingsComponent {
     { name: 'Treasure Reef', value: 'reef' },
     { name: 'Village of Dreams', value: 'cold' },
     { name: 'Crescent Oasis', value: 'sandy' },
+    { name: 'Days of Love', value: 'love' },
     { name: 'Void', value: 'dark' },
   ]
 

--- a/src/app/components/storage/storage.component.html
+++ b/src/app/components/storage/storage.component.html
@@ -28,11 +28,7 @@
   <div class="sky-card-body">
     <div class="container">
       <p>
-        On this page you can change how your tracked data is stored.
-      </p>
-      <p>
-        Information stored in your linked account is limited to unlocks such as items, in-app purchases, favourited items and winged light.
-        Settings are always stored locally.
+        On this page you can change how your tracked data is stored. There are a few exceptions to what is stored here; some settings may still be stored locally.
       </p>
       <p>
         You can import and export your data on the <b>Settings</b> page of the main website.<br/>

--- a/src/app/services/currency.service.ts
+++ b/src/app/services/currency.service.ts
@@ -63,6 +63,15 @@ export class CurrencyService {
     changed && this._storageService.setCurrencies(value);
   }
 
+  setRegularCost(cost: ICost): void {
+    const value = this._storageService.getCurrencies();
+    let changed = false;
+    if (cost.c !== undefined) { value.candles = this.clamp(cost.c); changed = true; }
+    if (cost.h !== undefined) { value.hearts = this.clamp(cost.h); changed = true; }
+    if (cost.ac !== undefined) { value.ascendedCandles = this.clamp(cost.ac); changed = true; }
+    changed && this._storageService.setCurrencies(value);
+  }
+
   addGiftPasses(value: number): void {
     if (!value) { return; }
     const currencies = this._storageService.getCurrencies();
@@ -100,6 +109,13 @@ export class CurrencyService {
     this._storageService.setCurrencies(currencies);
   }
 
+  setEventCurrency(eventGuid: string, value?: number): void {
+    if (!eventGuid || !value) { return; }
+    const currencies = this._storageService.getCurrencies();
+    currencies.eventCurrencies[eventGuid] = this.clamp(value);
+    this._storageService.setCurrencies(currencies);
+  }
+
   animateCurrencyGained(evt: MouseEvent, value: number): void {
     if (!value) { return; }
     const span = document.createElement('span');
@@ -121,7 +137,7 @@ export class CurrencyService {
     }, 1000);
   }
 
-  private clamp(value: number): number {
+  clamp(value: number): number {
     return Math.min(99999, Math.max(0, value));
   }
 }

--- a/src/app/services/currency.service.ts
+++ b/src/app/services/currency.service.ts
@@ -45,17 +45,18 @@ export class CurrencyService {
     // Event currency
     if (cost.ec && eventInstance && DateHelper.isActive(eventInstance.date, eventInstance.endDate)) {
       const guid = eventInstance.guid;
-      value.eventCurrencies[guid] = this.clamp((value.eventCurrencies[guid] ?? 0) + cost.ec);
+      const cur = value.eventCurrencies[guid] ?? { tickets: 0 };
+      value.eventCurrencies[guid] = cur;
+      cur.tickets = this.clamp((value.eventCurrencies[guid].tickets ?? 0) + cost.ec);
       changed = true;
     }
 
     // Season currency.
-    if ((cost.sc || cost.sh) && season && DateHelper.isActive(season.date, season.endDate)) {
+    if (cost.sc && season && DateHelper.isActive(season.date, season.endDate)) {
       const guid = season.guid;
-      const cur = value.seasonCurrencies[guid] ?? { candles: 0, hearts: 0 };
+      const cur = value.seasonCurrencies[guid] ?? { candles: 0 };
       value.seasonCurrencies[guid] = cur;
       cur.candles = this.clamp(cur.candles + (cost.sc || 0));
-      cur.hearts = this.clamp(cur.hearts + (cost.sh || 0));
       changed = true;
     }
 
@@ -80,39 +81,39 @@ export class CurrencyService {
     this._storageService.setCurrencies(currencies);
   }
 
-  addSeasonCurrency(seasonGuid: string, candles: number, hearts: number): void {
-    if (!seasonGuid || (!candles && !hearts)) { return; }
+  addSeasonCurrency(seasonGuid: string | undefined, candles?: number): void {
+    if (!seasonGuid || !candles) { return; }
     const value = this._storageService.getCurrencies();
-    const seasonCurrency = value.seasonCurrencies[seasonGuid] ?? { candles: 0, hearts: 0 };
+    const seasonCurrency = value.seasonCurrencies[seasonGuid] ?? { candles: 0 };
     value.seasonCurrencies[seasonGuid] = seasonCurrency;
-    seasonCurrency.candles += candles;
-    seasonCurrency.candles = this.clamp(seasonCurrency.candles);
-    seasonCurrency.hearts += hearts;
-    seasonCurrency.hearts = this.clamp(seasonCurrency.hearts);
+    seasonCurrency.candles = this.clamp((seasonCurrency.candles ?? 0) + candles);
     this._storageService.setCurrencies(value);
   }
 
-  setSeasonCurrency(seasonGuid: string, candles?: number, hearts?: number): void {
-    if (!seasonGuid || (!candles && !hearts)) { return; }
+  setSeasonCurrency(seasonGuid: string | undefined, candles?: number): void {
+    if (!seasonGuid || !candles) { return; }
     const value = this._storageService.getCurrencies();
-    const seasonCurrency = value.seasonCurrencies[seasonGuid] ?? { candles: 0, hearts: 0 };
+    const seasonCurrency = value.seasonCurrencies[seasonGuid] ?? { candles: 0 };
     value.seasonCurrencies[seasonGuid] = seasonCurrency;
-    if (candles !== undefined) { seasonCurrency.candles = this.clamp(candles); }
-    if (hearts !== undefined) { seasonCurrency.hearts = this.clamp(hearts); }
+    seasonCurrency.candles = this.clamp(candles);
     this._storageService.setCurrencies(value);
   }
 
   addEventCurrency(eventGuid: string, value: number): void {
     if (!eventGuid || !value) { return; }
     const currencies = this._storageService.getCurrencies();
-    currencies.eventCurrencies[eventGuid] = this.clamp((currencies.eventCurrencies[eventGuid] ?? 0) + value);
+    const eventCurrencies = currencies.eventCurrencies[eventGuid] ?? { tickets: 0 };
+    currencies.eventCurrencies[eventGuid] = eventCurrencies;
+    eventCurrencies.tickets = this.clamp((eventCurrencies.tickets ?? 0) + value);
     this._storageService.setCurrencies(currencies);
   }
 
   setEventCurrency(eventGuid: string, value?: number): void {
     if (!eventGuid || !value) { return; }
     const currencies = this._storageService.getCurrencies();
-    currencies.eventCurrencies[eventGuid] = this.clamp(value);
+    const eventCurrencies = currencies.eventCurrencies[eventGuid] ?? { tickets: 0 };
+    currencies.eventCurrencies[eventGuid] = eventCurrencies;
+    eventCurrencies.tickets = this.clamp(value);
     this._storageService.setCurrencies(currencies);
   }
 

--- a/src/app/services/currency.service.ts
+++ b/src/app/services/currency.service.ts
@@ -1,0 +1,106 @@
+import { Injectable } from '@angular/core';
+import { StorageService } from './storage.service';
+import { ICost } from '@app/interfaces/cost.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CurrencyService {
+  constructor(
+    private readonly _storageService: StorageService
+  ) {
+  }
+
+  addCost(cost: ICost): void {
+    const value = this._storageService.getCurrencies();
+    if (cost.c) {
+      value.candles += cost.c;
+      value.candles = this.clamp(value.candles);
+    }
+    if (cost.h) {
+      value.hearts += cost.h;
+      value.hearts = this.clamp(value.hearts);
+    }
+    if (cost.ac) {
+      value.ascendedCandles += cost.ac;
+      value.ascendedCandles = this.clamp(value.ascendedCandles);
+    }
+    this._storageService.setCurrencies(value);
+  }
+
+  subtractCost(cost: ICost): void {
+    const value = this._storageService.getCurrencies();
+    if (cost.c) {
+      value.candles -= cost.c;
+      value.candles = this.clamp(value.candles);
+    }
+    if (cost.h) {
+      value.hearts -= cost.h;
+      value.hearts = this.clamp(value.hearts);
+    }
+    if (cost.ac) {
+      value.ascendedCandles -= cost.ac;
+      value.ascendedCandles = this.clamp(value.ascendedCandles);
+    }
+    this._storageService.setCurrencies(value);
+  }
+
+  addGiftPasses(value: number): void {
+    if (!value) { return; }
+    const currencies = this._storageService.getCurrencies();
+    currencies.giftPasses += value;
+    currencies.giftPasses = this.clamp(currencies.giftPasses);
+    this._storageService.setCurrencies(currencies);
+  }
+
+  addSeasonCurrency(seasonGuid: string, candles: number, hearts: number): void {
+    if (!seasonGuid || (!candles && !hearts)) { return; }
+    const value = this._storageService.getCurrencies();
+    const seasonCurrency = value.seasonCurrencies[seasonGuid] ?? { candles: 0, hearts: 0 };
+    value.seasonCurrencies[seasonGuid] = seasonCurrency;
+    seasonCurrency.candles += candles;
+    seasonCurrency.candles = this.clamp(seasonCurrency.candles);
+    seasonCurrency.hearts += hearts;
+    seasonCurrency.hearts = this.clamp(seasonCurrency.hearts);
+    this._storageService.setCurrencies(value);
+  }
+
+  addEventCurrency(eventGuid: string, value: number): void {
+    if (!eventGuid || !value) { return; }
+    const currencies = this._storageService.getCurrencies();
+    currencies.eventCurrencies[eventGuid] = this.clamp((currencies.eventCurrencies[eventGuid] ?? 0) + value);
+    this._storageService.setCurrencies(currencies);
+  }
+
+  animateCurrencyGained(evt: MouseEvent, value: number): void {
+    if (!value) { return; }
+    const span = document.createElement('span');
+    span.style.position = 'fixed';
+    span.classList.add('currency-gained');
+    span.textContent = value >= 0 ? `+${value}` : `${value}`;
+    span.style.top = `${evt.clientY}px`;
+    span.style.left = `${evt.clientX}px`;
+    span.style.transform = 'translate(-50%, -50%)';
+    span.style.lineHeight = '24px';
+    span.style.fontSize = '24px';
+    span.style.color = '#fff';
+    span.style.textShadow = '2px 2px 4px rgba(0, 0, 0, 1)';
+    span.style.pointerEvents = 'none';
+    span.classList.add(value < 0 ? 'c-old' : 'c-new');
+    document.body.appendChild(span);
+    const interval = setInterval(() => {
+      const top = parseInt(span.style.top, 10);
+      span.style.top =  `${top - 1}px`;
+      const opacity = parseFloat(span.style.opacity || '1');
+      span.style.opacity = `${Math.max(0, opacity - 0.02)}`;
+    }, 20);
+    setTimeout(() => {
+      clearInterval(interval);
+      span.remove();
+    }, 1000);
+  }
+
+  private clamp(value: number): number {
+    return Math.min(99999, Math.max(0, value));
+  }
+}

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Subject, SubscriptionLike } from 'rxjs';
-import { IStorageEvent, IStorageExport, IStorageProvider } from './storage/storage-provider.interface';
+import { IStorageCurrencies, IStorageEvent, IStorageExport, IStorageProvider } from './storage/storage-provider.interface';
 import { StorageProviderFactory } from './storage/storage-provider-factory';
 import { BroadcastService } from './broadcast.service';
 
@@ -36,6 +36,14 @@ export class StorageService implements OnDestroy {
 
   export(): IStorageExport {
     return this.provider.export();
+  }
+
+  getCurrencies(): IStorageCurrencies {
+    return JSON.parse(JSON.stringify(this.provider.getCurrencies()));
+  }
+  setCurrencies(currency: IStorageCurrencies): void {
+    this.provider.setCurrencies(currency);
+    this.notifyChange();
   }
 
   getUnlocked(): ReadonlySet<string> { return this.provider.getUnlocked(); }

--- a/src/app/services/storage/dropbox-storage-provider.ts
+++ b/src/app/services/storage/dropbox-storage-provider.ts
@@ -3,9 +3,11 @@ import { Observable, concatMap, of } from 'rxjs';
 import { Injectable, OnDestroy } from '@angular/core';
 import { BaseStorageProvider } from './base-storage-provider';
 import { DropboxService } from '../dropbox.service';
+import { IStorageCurrencies } from './storage-provider.interface';
 
 interface IDropboxData {
   date: string;
+  currencies: IStorageCurrencies;
   unlocked: string;
   wingedLights: string;
   favourites: string;
@@ -24,8 +26,6 @@ export class DropboxStorageProvider extends BaseStorageProvider implements OnDes
   override _syncDate: DateTime;
 
   private _rev?: string;
-  private _accessToken?: string;
-  private _refreshToken?: string;
 
   constructor(
     private readonly _dropboxService: DropboxService
@@ -88,22 +88,19 @@ export class DropboxStorageProvider extends BaseStorageProvider implements OnDes
 
   private initializeData(data: Partial<IDropboxData>): void {
     this._syncDate = data.date ? DateTime.fromISO(data.date) as DateTime : DateTime.now();
-    const unlocked = data.unlocked || undefined;
-    const wingedLights = data.wingedLights || undefined;
-    const favourites = data.favourites || undefined;
-    const seasonPasses = data.seasonPasses || undefined;
-    const mapMarkers = data.mapMarkers || undefined;
-    this._unlocked = new Set(unlocked?.split(',') ?? []);
-    this._wingedLights = new Set(wingedLights?.split(',') ?? []);
-    this._favourites = new Set(favourites?.split(',') ?? []);
-    this._seasonPasses = new Set(seasonPasses?.split(',') ?? []);
-    this._mapMarkers = new Set(mapMarkers?.split(',') ?? []);
+    this._currencies = data.currencies || { candles: 0, hearts: 0, ascendedCandles: 0, giftPasses: 0, eventCurrencies: {}, seasonCurrencies: {} };;
+    this._unlocked = new Set((data.unlocked || undefined)?.split(',') ?? []);
+    this._wingedLights = new Set((data.wingedLights || undefined)?.split(',') ?? []);
+    this._favourites = new Set((data.favourites || undefined)?.split(',') ?? []);
+    this._seasonPasses = new Set((data.seasonPasses || undefined)?.split(',') ?? []);
+    this._mapMarkers = new Set((data.mapMarkers || undefined)?.split(',') ?? []);
     this._keys = data.keys || {};
   }
 
   private serializeData(): IDropboxData {
     return {
       date: this._syncDate.toISO()!,
+      currencies: this._currencies,
       unlocked: [...this._unlocked].join(','),
       wingedLights: [...this._wingedLights].join(','),
       favourites: [...this._favourites].join(','),

--- a/src/app/services/storage/local-storage-provider.ts
+++ b/src/app/services/storage/local-storage-provider.ts
@@ -5,6 +5,7 @@ import { BaseStorageProvider } from './base-storage-provider';
 
 const storageKeys = {
   date: 'date',
+  currencies: 'currencies',
   unlocked: 'unlocked',
   wingedLights: 'wingedLights',
   favourites: 'favourites',
@@ -36,12 +37,25 @@ export class LocalStorageProvider extends BaseStorageProvider {
   override load(): Observable<void> {
     const date = localStorage.getItem(storageKeys.date) || '';
     const unlocked = localStorage.getItem(storageKeys.unlocked) || '';
+    let currencies = JSON.parse(localStorage.getItem(storageKeys.currencies) || '{}');
+    if (Object.keys(currencies).length === 0) {
+      currencies = { candles: 0, hearts: 0, ascendedCandles: 0, giftPasses: 0, eventCurrencies: {}, seasonCurrencies: {} };
+    }
     const wingedLights = localStorage.getItem(storageKeys.wingedLights) || '';
     const favourites = localStorage.getItem(storageKeys.favourites) || '';
     const seasonPasses = localStorage.getItem(storageKeys.seasonPasses) || '';
     const mapMarkers = localStorage.getItem(storageKeys.mapMarkers) || '';
     const data = JSON.parse(localStorage.getItem(storageKeys.keys) || '{}');
-    this.import({ date, unlocked, wingedLights, favourites, seasonPasses, mapMarkers, keys: data });
+    this.import({
+      date,
+      currencies: currencies || { candles: 0, hearts: 0, ascendedCandles: 0, giftPasses: 0, eventCurrencies: {}, seasonCurrencies: {} },
+      unlocked,
+      wingedLights,
+      favourites,
+      seasonPasses,
+      mapMarkers,
+      keys: data
+    });
     return of(undefined);
   }
 
@@ -49,6 +63,7 @@ export class LocalStorageProvider extends BaseStorageProvider {
     this.events.next({ type: 'save_start' });
     const data = this.export();
     localStorage.setItem(storageKeys.date, this._lastDate.toISO()!);
+    localStorage.setItem(storageKeys.currencies, JSON.stringify(data.currencies));
     localStorage.setItem(storageKeys.unlocked, data.unlocked);
     localStorage.setItem(storageKeys.wingedLights, data.wingedLights);
     localStorage.setItem(storageKeys.favourites, data.favourites);

--- a/src/app/services/storage/storage-provider.interface.ts
+++ b/src/app/services/storage/storage-provider.interface.ts
@@ -10,8 +10,18 @@ export interface IStorageEvent {
   error?: Error;
 }
 
+export interface IStorageCurrencies {
+  candles: number;
+  hearts: number;
+  ascendedCandles: number;
+  giftPasses: number;
+  eventCurrencies: { [key: string]: number };
+  seasonCurrencies: { [key: string]: { candles: number; hearts: number } };
+}
+
 export interface IStorageExport {
   date: string;
+  currencies: IStorageCurrencies;
   unlocked: string;
   wingedLights: string;
   favourites: string;
@@ -23,6 +33,7 @@ export interface IStorageExport {
 export interface IStorageProvider {
   _lastDate: DateTime;
   _syncDate: DateTime;
+  _currencies: IStorageCurrencies;
   _unlocked: Set<string>;
   _favourites: Set<string>;
   _seasonPasses: Set<string>;
@@ -39,6 +50,9 @@ export interface IStorageProvider {
   export(): IStorageExport;
   getSyncDate(): DateTime;
   isOutOfSync(): boolean;
+
+  getCurrencies(): IStorageCurrencies;
+  setCurrencies(currencies: IStorageCurrencies): void;
 
   getUnlocked(): ReadonlySet<string>;
   addUnlocked(...guids: Array<string>): void;

--- a/src/app/services/storage/storage-provider.interface.ts
+++ b/src/app/services/storage/storage-provider.interface.ts
@@ -15,8 +15,8 @@ export interface IStorageCurrencies {
   hearts: number;
   ascendedCandles: number;
   giftPasses: number;
-  eventCurrencies: { [key: string]: number };
-  seasonCurrencies: { [key: string]: { candles: number; hearts: number } };
+  eventCurrencies: { [key: string]: { tickets: number } };
+  seasonCurrencies: { [key: string]: { candles: number } };
 }
 
 export interface IStorageExport {

--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -331,7 +331,7 @@
         {
           "guid": "Nw1QP8vccL",
           "date": "2024-06-24",
-          "endDate": "2024-07-07",
+          "endDate": "2024-09-07",
           "calculatorData": {
             "dailyCurrencyAmount": 5
           },

--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -331,7 +331,7 @@
         {
           "guid": "Nw1QP8vccL",
           "date": "2024-06-24",
-          "endDate": "2024-09-07",
+          "endDate": "2024-07-07",
           "calculatorData": {
             "dailyCurrencyAmount": 5
           },

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -491,6 +491,16 @@ mat-icon.seasonal { fill: var(--color-seasonal); }
   animation: spin 2s linear infinite;
 }
 
+.currency-gained {
+  position: fixed;
+  transform: translate(-50%, -50%);
+  line-height: 24px;
+  font-size: 24px;
+  color: #fff;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 1);
+  pointer-events: none;
+}
+
 /* Intro.js */
 .introjs-tooltip {
   color: #000;

--- a/src/styles/vars.scss
+++ b/src/styles/vars.scss
@@ -168,4 +168,11 @@
   --background: url(/assets/game/background/void_jelly.webp);
 }
 
+:root[data-theme="love"] {
+  --hue: 205;
+  --saturation: 70%;
+
+  --background: url(/assets/game/background/love2024.webp);
+}
+
 // #endregion


### PR DESCRIPTION
* Adds a new currency page to track your in-game currencies.
  * Season hearts are left out because it's less relevant to track them.. but really because they're more difficult as they're the only currency that can be unlocked through spirit trees.
* Currencies automatically convert (season candles) or disappear (event currency) when the season/event ends **when you open the currency page**.
* Currencies are shared between the currency page and calculators.
* Checking in dailies on the dashboard updates the season and event currency (with a fancy animation).
* Unlocking items in spirit trees and in-game currency shops will update your currency counts.
* Unlocking IAPs with in-game currency or gift passes will update your currency counts.
* Unlocking items in calculators will update your currency counts.
* Calculator will use your season pass owned indicator to change the +6/5 candle button to add daily candles more easily (i.e. if you didn't open Sky Planner a couple of days and want to quickly add these days to your candles).

![image](https://github.com/user-attachments/assets/c67470f1-c260-47ef-bb52-67a692dda01b)
![xQoJnMjozP](https://github.com/user-attachments/assets/91c47e1c-b210-487d-8627-8a41e45e822c)

Closes #141, closes #138 
Related #132 