### PR TITLE
Update double light event dates

### DIFF
--- a/src/assets/data/seasons.json
+++ b/src/assets/data/seasons.json
@@ -481,7 +481,7 @@
       ],
       "calculatorData": {
         "timedCurrency": [
-          { "guid": "y0Ov41RCWP", "date": "2024-09-09", "endDate": "2024-09-15", "amount": 7 }
+          { "guid": "y0Ov41RCWP", "date": "2024-09-09", "endDate": "2024-09-29", "amount": 21 }
         ]
       },
       "_wiki": {


### PR DESCRIPTION
On the discord it was announced [the double light event is getting extended by an additional two weeks](https://discord.com/channels/575762611111592007/575768778789617674/1281403405176410194).