### PR TITLE
Fix inflation chart crashing when trying to render trendline

### DIFF
--- a/src/app/components/items/item-inflation/item-inflation.component.ts
+++ b/src/app/components/items/item-inflation/item-inflation.component.ts
@@ -221,22 +221,28 @@ export class ItemInflationComponent implements AfterViewInit {
       spanGaps: true,
       hidden: true
     });
-    (this.chart.data.datasets[0] as any).trendlineLinear = {
-      style: '#8e5ea2',
-      lineStyle: 'line',
-      width: 1
-    };
+
+    if (dataAdd.length > 1) {
+      (this.chart.data.datasets[0] as any).trendlineLinear = {
+        style: '#8e5ea2',
+        lineStyle: 'line',
+        width: 1
+      };
+    }
 
     this.chart.data.datasets.push({
       label: 'Items by first return date',
       data: dataReturn,
       spanGaps: true
     });
-    (this.chart.data.datasets[1] as any).trendlineLinear = {
-      style: '#3e95cd',
-      lineStyle: 'line',
-      width: 1
-    };
+
+    if (dataReturn.length > 1) {
+      (this.chart.data.datasets[1] as any).trendlineLinear = {
+        style: '#3e95cd',
+        lineStyle: 'line',
+        width: 1
+      };
+    }
 
     while (currentDate <= maxDate.endOf('month')) {
       const sDate = currentDate.toFormat('MMM yy').replace(' ', " '");


### PR DESCRIPTION
# Bug description

When opening [Item inflation](https://sky-planner.com/item/inflation) and filtering for Shoes, the chart crashes and the only way to get it back is refreshing the page.

# Root cause

The error is caused by the package not being able to render the trending line for a single item.
https://stackoverflow.com/a/75898415

# Solution

I added a check to see if the datalist's lenght is greater than 1 in order to set the trendline styles