### PR TITLE
Update days of sunlight 2025

### DIFF
--- a/src/assets/data/items/days-of-sunlight.json
+++ b/src/assets/data/items/days-of-sunlight.json
@@ -197,6 +197,7 @@
     "order": 368,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Bonnet"
+    }
   },
   {
     "id": 2740,
@@ -208,6 +209,7 @@
     "order": 80,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Sun_Dress"
+    }
   },
   {
     "id": 2741,
@@ -219,6 +221,7 @@
     "order": 643,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Wave_Projector"
+    }
   },
   {
     "id": 2742,
@@ -234,6 +237,7 @@
     "order": 926,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sunlight_Shawl_Cape"
+    }
   },
   {
     "id": 2743,
@@ -245,6 +249,7 @@
     "order": 644,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sandcastle_Small_Tower_Piece"
+    }
   },
   {
     "id": 2744,
@@ -256,6 +261,7 @@
     "order": 645,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sandcastle_Large_Tower_Piece"
+    }
   },
   {
     "id": 2745,
@@ -267,6 +273,7 @@
     "order": 646,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sandcastle_Small_Gate_Piece"
+    }
   },
   {
     "id": 2746,
@@ -278,6 +285,7 @@
     "order": 647,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sandcastle_Wall_Piece"
+    }
   },
   {
     "id": 2747,
@@ -289,6 +297,7 @@
     "order": 648,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sandcastle_Large_Gate_Piece"
+    }
   },
   {
     "id": 2748,
@@ -300,6 +309,7 @@
     "order": 649,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sandcastle_Sand_Lot"
+    }
   },
   {
     "id": 2749,
@@ -311,6 +321,7 @@
     "order": 650,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight#Sandcastle_Flag"
+    }
   },
   {
     "id": 2750,


### PR DESCRIPTION
Updated the new items of Days of Sunlight 2025, on Icon link, Preview image, and with Wiki link.