### PR TITLE
Updated with TS 148

### DIFF
--- a/src/assets/data/nodes/seasons.json
+++ b/src/assets/data/nodes/seasons.json
@@ -869,6 +869,18 @@
   { "guid": "_uYomTIaR7", "item": "usBrZiK7JN", "c": 5, "nw": "CeHqTmECfL", "n": "mjnoDrbqGi" },
   { "guid": "CeHqTmECfL", "item": "HzMNk4W-bM", "c": 34 },
   { "guid": "mjnoDrbqGi", "item": "wSjNwu664c", "c": 42 },
+  // TS Error
+  { "guid": "O8QA3nIMbC", "item": "YnKXRCy5y9", "nw": "rgiQqZO6aU", "n": "vRo8L9GdZ_" },
+  { "guid": "rgiQqZO6aU", "item": "LPnwWeKlf0", "h": 4 },
+  { "guid": "vRo8L9GdZ_", "item": "Yg9fTjQQAK", "c": 5, "nw": "sOnWNvfLdO", "n": "RcxHMJcuAK", "ne": "5x6WqBXVIf" },
+  { "guid": "sOnWNvfLdO", "item": "kWs-MLO3ZE", "c": 15 },
+  { "guid": "5x6WqBXVIf", "item": "SEpK8eiz2W", "c": 3 },
+  { "guid": "RcxHMJcuAK", "item": "Foy_7SpHIY", "ac": 2, "n": "nuNlzT_sDu" },
+  { "guid": "nuNlzT_sDu", "item": "oTQGUs9w8K", "h": 3, "nw": "wSusMbjv5A", "n": "qJF6NgROpf" },
+  { "guid": "wSusMbjv5A", "item": "znqKbunN1C", "h": 6 },
+  { "guid": "qJF6NgROpf", "item": "usBrZiK7JN", "c": 5, "nw": "a2oeDGD78w", "n": "wPDLW-eV1K" },
+  { "guid": "a2oeDGD78w", "item": "HzMNk4W-bM", "c": 34 },
+  { "guid": "wPDLW-eV1K", "item": "wSjNwu664c", "c": 42 },
   // TS 184
   { "guid": "TfqS8fRZYJ", "item": "YnKXRCy5y9", "nw": "ooOJqrV35E", "n": "SzHMJJjlOk" },
   { "guid": "ooOJqrV35E", "item": "LPnwWeKlf0", "h": 4 },
@@ -2747,7 +2759,7 @@
   { "guid": "aRad3pvIRz", "item": "1tF2KjdUWO", "sc": 20, "nw": "_VqBZBJaqD", "n": "Qlcl9nQNjH" },
   { "guid": "_VqBZBJaqD", "item": "kurDiTSM-m" },
   { "guid": "Qlcl9nQNjH", "item": "GJt1fejM0x", "sc": 3 },
-  //SV 1
+  // SV 1
   { "guid": "I-40Dn5_LO", "item": "KyJwYhzGVj", "nw": "OntmTSdg1H", "n": "nBqoZxfYaj" },
   { "guid": "OntmTSdg1H", "item": "owZSOBEp_z", "h": 4 },
   { "guid": "nBqoZxfYaj", "item": "-LT5Xt5vpH", "c": 5, "nw": "6X3GYV3oRD", "n": "ug-qh9LY4k", "ne": "90Wt1MVqIq" },
@@ -2760,7 +2772,7 @@
   { "guid": "YYqN0pEiuk", "item": "kurDiTSM-m", "c": 5, "nw": "ezHg6ju-Tm", "n": "95xIjB2Opx" },
   { "guid": "ezHg6ju-Tm", "item": "g8AB_9bQIK", "c": 45 },
   { "guid": "95xIjB2Opx", "item": "1tF2KjdUWO", "c": 55 },
-  //TS 147
+  // TS 147
   { "guid": "favqmKiY2h", "item": "KyJwYhzGVj", "nw": "XuHmk3AnqK", "n": "psN9kg5B81" },
   { "guid": "XuHmk3AnqK", "item": "owZSOBEp_z", "h": 4 },
   { "guid": "psN9kg5B81", "item": "-LT5Xt5vpH", "c": 5, "nw": "yWHmQjPeQV", "n": "FxlsIYODv6", "ne": "WnIToYZGir" },
@@ -2772,7 +2784,7 @@
   { "guid": "ASbhrCTIe5", "item": "gEKj_Dz9vX", "c": 15 },
   { "guid": "XT2JYfdOXt", "item": "kurDiTSM-m", "c": 5, "nw": "HvNFTyRKXl", "n": "AQkN49QXXH" },
   { "guid": "HvNFTyRKXl", "item": "g8AB_9bQIK", "c": 45 },
-  { "guid": "AQkN49QXXH", "item": "1tF2KjdUWO", "c": 55 }
+  { "guid": "AQkN49QXXH", "item": "1tF2KjdUWO", "c": 55 },
   // Marching Adventurer
   { "guid": "x1a7G7bveD", "item": "dNoANrAQV0", "nw": "7cLmkfOUJE", "n": "4UkX0dtia1" },
   { "guid": "7cLmkfOUJE", "item": "0xqk-p9fsY" },

--- a/src/assets/data/returning-spirits.json
+++ b/src/assets/data/returning-spirits.json
@@ -17,6 +17,16 @@
       }
     },
     {
+      "guid": "7tvWNUHLPq",
+      "name": "TS Error",
+      "area": "zewkN917oz",
+      "date": { "day": 13, "month": 4, "year": 2023 },
+      "endDate": { "day": 13, "month": 4, "year": 2023 },
+      "spirits": [
+        { "guid": "dvrEFaKH9W", "spirit": "lmydkMDQeP", "tree": "KcxP_uWRx_" }
+      ]
+    },
+    {
       "guid": "qEAUu9cHFK",
       "name": "Special Visit #2",
       "area": "Xr2ZiVSV7p",

--- a/src/assets/data/spirit-trees.json
+++ b/src/assets/data/spirit-trees.json
@@ -499,6 +499,11 @@
       "guid": "T6wagFF_ls",
       "node": "TfqS8fRZYJ"
     },
+    // TS Error
+    {
+      "guid": "JHT-EOASCu",
+      "node": "4iDQf4wkrh"
+    },
     // TS 148
     {
       "guid": "KcxP_uWRx_",

--- a/src/assets/data/traveling-spirits.json
+++ b/src/assets/data/traveling-spirits.json
@@ -885,7 +885,7 @@
     },
     {
       "guid": "njkhN56zfF", // 148 - Provoking Performer
-      "date": "11-09-2025",
+      "date": "2025-09-11",
       "spirit": "lmydkMDQeP",
       "tree": "T6wagFF_ls"
     }


### PR DESCRIPTION
Updated the TS 148 (Provoking Performer) and removed a spirit tree named "TS error" from the Special Visit.