### PR TITLE
fix: remove duplicate area refrences in vault

### DIFF
--- a/src/assets/data/realms.json
+++ b/src/assets/data/realms.json
@@ -474,8 +474,6 @@
         "aBL5eqTv4R",
         "QnPzVZ6PyJ",
         "DERcWzmOL7",
-        "XG3_0khlw9",
-        "aBL5eqTv4R",
         "wOM-k6pjot",
         "2YCd4ckP6e",
         "schNrmq0ID",


### PR DESCRIPTION
`Crescent Oasis` and `Repository of Refuge` were being referenced twice (already at `L473-474`) in Vault's areas