### PR TITLE
Updated Show and Tell event image

### DIFF
--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -1372,7 +1372,7 @@
       "guid": "FH0tm4guOI",
       "name": "Workshop Show & Tell",
       "shortName": "Show & Tell",
-      "imageUrl": "https://i.imgur.com/0xUpfEj.png",
+      "imageUrl": "https://a.storyblok.com/f/287633541632220/1920x1080/9e4fa0e0b0/img_0012.jpeg"
       "imagePosition": "top",
       "instances": [
         {

--- a/src/assets/data/events.json
+++ b/src/assets/data/events.json
@@ -1372,7 +1372,7 @@
       "guid": "FH0tm4guOI",
       "name": "Workshop Show & Tell",
       "shortName": "Show & Tell",
-      "imageUrl": "https://a.storyblok.com/f/287633541632220/1920x1080/9e4fa0e0b0/img_0012.jpeg"
+      "imageUrl": "https://a.storyblok.com/f/287633541632220/1920x1080/9e4fa0e0b0/img_0012.jpeg",
       "imagePosition": "top",
       "instances": [
         {


### PR DESCRIPTION
Since Imgur is now blocked in the UK I’ve updated it with an image link using storyblok, which other event images use, since it isn’t blocked 
<img width="603" height="1311" alt="IMG_0010" src="https://github.com/user-attachments/assets/f0c9ca74-de79-4764-b963-ce7fb0aa2038" />
<img width="603" height="1311" alt="IMG_0011" src="https://github.com/user-attachments/assets/465982a4-f73a-4b83-b33d-93e96ccd98dc" />
