### PR TITLE
Updated Migration Guide's Spirit tree

### DIFF
--- a/src/assets/data/items/season-of-migration.json
+++ b/src/assets/data/items/season-of-migration.json
@@ -72,9 +72,9 @@
   {
     "id": 2829,
     "guid": "7TtaA7y6DH",
-    "type": "Special",
-    "name": "Placeholder",
-    "icon": ""
+    "type": "Quest",
+    "name": "Quest 2",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png"
   },
   {
     "id": 2766,
@@ -628,5 +628,33 @@
     "name": "Season Heart",
     "group": "SeasonPass",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Season-of-Migration-Heart.png"
+  },
+  {
+    "id": 2853,
+    "guid": "muha_qJwpZ",
+    "type": "Special",
+    "name": "Placeholder",
+    "icon": ""
+  },
+  {
+    "id": 2854,
+    "guid": "0f_K0ZZDvt",
+    "type": "Special",
+    "name": "Heart",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Heart.png"
+  },
+  {
+    "id": 2855,
+    "guid": "eO59rVUk-J",
+    "type": "Special",
+    "name": "Placeholder",
+    "icon": ""
+  },
+  {
+    "id": 2856,
+    "guid": "QGqFI8P5eX",
+    "type": "Special",
+    "name": "Heart",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Heart.png"
   }
 ]

--- a/src/assets/data/nodes/seasons.json
+++ b/src/assets/data/nodes/seasons.json
@@ -4460,6 +4460,10 @@
   { "guid": "RTje2sQbDf", "item": "Q5L4uyGTZh" },
   { "guid": "BvZNonEg4z", "item": "yArVcGtuj9" },
   { "guid": "DEjV0YzK4j", "item": "7TtaA7y6DH" },
+  { "guid": "eoqXwyNVfY", "item": "muha_qJwpZ" },
+  { "guid": "tzI9RG4290", "item": "0f_K0ZZDvt" },
+  { "guid": "zoNkAU2lUv", "item": "eO59rVUk-J" },
+  { "guid": "NQLhGo3wVU", "item": "QGqFI8P5eX" },
   // Migrating Jelly Whisperer
   { "guid": "oMjOf1Mc8_", "item": "RoTa6R2sVl" },
   { "guid": "3eKQmuhjHr", "item": "ePRlu9HXLu", "sc": 2 },

--- a/src/assets/data/spirit-tree-tiers.json
+++ b/src/assets/data/spirit-tree-tiers.json
@@ -13,7 +13,8 @@
       "guid": "YWnCYj7kWc",
       "next": "1UIzCdcZT8",
       "rows": [
-        [null, null, "Fj6_fYi-LK"]
+        ["eoqXwyNVfY", "tzI9RG4290", "Fj6_fYi-LK"],
+        ["zoNkAU2lUv", "NQLhGo3wVU", null]
       ]
     },
     {


### PR DESCRIPTION
Added the 2nd quest, the 2 hearts that are available, and placeholders for the next two quests 

Reference of spirit tree:
<img width="359" height="860" alt="image" src="https://github.com/user-attachments/assets/941d7045-8808-4b1e-80f7-e2af1f67677a" />

In-game spirit tree:
<img width="1533" height="1036" alt="image" src="https://github.com/user-attachments/assets/92bcc497-f8cf-4745-a243-4bc1074f9da5" />
