### PR TITLE
Updated Migration Guide Spirit Tree Q.4

### DIFF
--- a/src/assets/data/items/season-of-migration.json
+++ b/src/assets/data/items/season-of-migration.json
@@ -705,5 +705,12 @@
     "type": "Special",
     "name": "Heart",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Heart.png"
+  },
+  {
+    "id": 2864,
+    "guid": "cBfZD5uyzo",
+    "type":"Special",
+    "name": "Placeholder",
+    "icon": ""
   }
 ]

--- a/src/assets/data/nodes/seasons.json
+++ b/src/assets/data/nodes/seasons.json
@@ -4483,6 +4483,7 @@
   { "guid": "oGvTrwgIck", "item": "-6HGDtS9Ax"},
   { "guid": "8kcD2KTQ_x", "item": "52qGpxeSzO"},
   { "guid": "L1I8Uo47XP", "item": "HuPhXSOb0L"},
+  { "guid": "dKE6PlUw3l", "item": "cBfZD5uyzo"},
   // Migrating Jelly Whisperer
   { "guid": "oMjOf1Mc8_", "item": "RoTa6R2sVl" },
   { "guid": "3eKQmuhjHr", "item": "ePRlu9HXLu", "sc": 2 },

--- a/src/assets/data/spirit-tree-tiers.json
+++ b/src/assets/data/spirit-tree-tiers.json
@@ -27,8 +27,15 @@
     },
     {
       "guid": "06bMCCbKaA",
+      "next": "E_XoDpiiWX",
       "rows": [
         ["oGvTrwgIck","8kcD2KTQ_x","L1I8Uo47XP"]
+      ]
+    },
+    {
+      "guid": "E_XoDpiiWX",
+      "rows": [
+        ["dKE6PlUw3l", null, null]
       ]
     },
     // Migrating Jelly Whisperer


### PR DESCRIPTION
Updated the _Migration Guide spirit tree_ with the _Quest 4_ and some other _items/icons_ which are all unlocked/visible now.