### PR TITLE
Removed Row on Migration Guide Tree

### DIFF
--- a/src/assets/data/spirit-tree-tiers.json
+++ b/src/assets/data/spirit-tree-tiers.json
@@ -27,14 +27,8 @@
     },
     {
       "guid": "06bMCCbKaA",
-      "next": "E_XoDpiiWX",
       "rows": [
-        ["oGvTrwgIck","8kcD2KTQ_x","L1I8Uo47XP"]
-      ]
-    },
-    {
-      "guid": "E_XoDpiiWX",
-      "rows": [
+        ["oGvTrwgIck","8kcD2KTQ_x","L1I8Uo47XP"],
         ["dKE6PlUw3l", null, null]
       ]
     },


### PR DESCRIPTION
Moved the placeholder from the top row to the row below and deleted the top row since its not needed (for now) to match the in-game tree

Current tree:
<img width="289" height="707" alt="image" src="https://github.com/user-attachments/assets/5bc46bd8-59cd-4647-aa45-60dc9f9969a5" />

Revised tree:
<img width="258" height="735" alt="image" src="https://github.com/user-attachments/assets/7bc98e0a-c41b-4079-b6ba-927f022a9baf" />

In-game tree:
<img width="631" height="864" alt="image" src="https://github.com/user-attachments/assets/55c1bc96-d732-45b9-81a1-219da17b6c33" />
