### PR TITLE
Add shortcuts to web manifest

### DIFF
--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -64,18 +64,18 @@
     },
     {
       "name": "Events",
-      "description": "Go to shops",
+      "description": "Go to events",
       "url": "/event"
     },
     {
-      "name": "Realms",
-      "description": "Go to realms",
-      "url": "/realm"
+      "name": "Items",
+      "description": "Go to items",
+      "url": "/item"
     },
     {
-      "name": "Shops",
-      "description": "Go to shops",
-      "url": "/shop"
+      "name": "Spirits",
+      "description": "Go to spirits",
+      "url": "/spirits"
     }
   ]
 }


### PR DESCRIPTION
This lets you show a context menu with pre defined shortcuts which can be very userfull

![Screenshot_20260118_052811_One UI Home](https://github.com/user-attachments/assets/f4d47a2a-ad91-429e-9ea1-ff2240e7bc82)

Most browser supports this, except for few like firefox and safari on ios ([browser compatibility](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/shortcuts#browser_compatibility))

Some platform only shows 4 shortcuts so I didn't add anymore. This probably should be dependant on which pages are more visited but I don't have access to that analytics. 